### PR TITLE
fix: RSS UGC hardening

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -82,6 +82,30 @@ bots:
 `),
     ).toThrow();
   });
+
+  it("rejects config with display_name over 100 chars", () => {
+    expect(() =>
+      parseConfig(`
+bots:
+  test:
+    feed_url: "https://example.com/rss"
+    display_name: "${"x".repeat(101)}"
+    summary: "A bot"
+`),
+    ).toThrow();
+  });
+
+  it("rejects config with summary over 500 chars", () => {
+    expect(() =>
+      parseConfig(`
+bots:
+  test:
+    feed_url: "https://example.com/rss"
+    display_name: "Test"
+    summary: "${"y".repeat(501)}"
+`),
+    ).toThrow();
+  });
 });
 
 describe("loadConfig", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,10 +2,13 @@ import { readFileSync } from "node:fs";
 import { load as parseYaml } from "js-yaml";
 import { z } from "zod";
 
+const MAX_DISPLAY_NAME_LENGTH = 100;
+const MAX_SUMMARY_LENGTH = 500;
+
 const BotSchema = z.object({
   feed_url: z.string().url(),
-  display_name: z.string().min(1),
-  summary: z.string().min(1),
+  display_name: z.string().min(1).max(MAX_DISPLAY_NAME_LENGTH),
+  summary: z.string().min(1).max(MAX_SUMMARY_LENGTH),
 });
 
 export const FeedsConfigSchema = z.object({

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -93,7 +93,8 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
           items: entries.map((e) =>
             buildCreateActivity(
               identifier,
-              { ...e, link: e.url },
+              e.id,
+              { title: e.title, link: e.url, publishedAt: e.publishedAt },
               ctx.url,
             ),
           ),


### PR DESCRIPTION
Implements the **security work tree** items from the audit plan.

## Changes

1. **Server-generated IDs for Note URIs**  
   - Use DB `id` in all public Note/outbox URLs; feed `guid` is only stored for deduplication.  
   - `insertEntry` returns the new row id (or `null` on conflict).  
   - No feed-supplied data in URLs.

2. **Safe URLs (http/https only)**  
   - `safeParseUrl()` allows only `http:` and `https:`.  
   - Note `url` and content `<a href>` use it; `javascript:`, `data:`, `vbscript:` are rejected.

3. **HTML escaping**  
   - Escape single quote (`'` → `&#39;`) in `escapeHtml` for defense-in-depth.

4. **Input validation and DoS**  
   - Max lengths: title 2000, url 2048, guid 2048 (truncate before insert and in Note).  
   - Per-feed item cap: `MAX_ITEMS_PER_POLL = 100` in `fetchFeed` / `parseFeedXml`.

5. **Config limits**  
   - `display_name` max 100 chars, `summary` max 500 chars (Zod validation).

## Tests

- `safeParseUrl`: dangerous schemes, http/https, invalid input.  
- `buildCreateActivity`: no dangerous URL in Note, escaping (quotes, script, single quote).  
- `truncateToMax`, `publishNewEntries` with over-long title/link/guid.  
- `parseFeedXml`: item cap at `MAX_ITEMS_PER_POLL`.  
- Config: reject `display_name` > 100 and `summary` > 500.

Ref: Two-work-tree audit plan (this work tree = security only).