### PR TITLE
fix: block list, Reject on Follow, NodeInfo, landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A running PostgreSQL instance is required. The application will apply any necess
 | `DOMAIN` | Public domain the server is running on (used for ActivityPub IDs and WebFinger) | (required) |
 | `PORT` | HTTP server port | `3000` |
 | `POLL_INTERVAL_MS` | Milliseconds between RSS poll cycles | `300000` (5 min) |
+| `BLOCKED_INSTANCES` | Comma-separated instance hostnames to reject Follows from (e.g. `spam.example,bad.example`) | (none) |
 
 ## Scripts
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { parseConfig, loadConfig } from "../config.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getBlockedInstances, parseConfig, loadConfig } from "../config.js";
 import { join } from "node:path";
 
 describe("parseConfig", () => {
@@ -92,5 +92,30 @@ describe("loadConfig", () => {
       expect(bot.feed_url).toMatch(/^https?:\/\//);
       expect(bot.display_name.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("getBlockedInstances", () => {
+  const envKey = "BLOCKED_INSTANCES";
+
+  afterEach(() => {
+    delete process.env[envKey];
+  });
+
+  it("returns empty set when BLOCKED_INSTANCES is unset", () => {
+    expect(getBlockedInstances()).toEqual(new Set());
+  });
+
+  it("returns empty set when BLOCKED_INSTANCES is empty string", () => {
+    process.env[envKey] = "";
+    expect(getBlockedInstances()).toEqual(new Set());
+  });
+
+  it("parses comma-separated hostnames and lowercases them", () => {
+    process.env[envKey] = "Spam.Example.COM , bad.instance";
+    const blocked = getBlockedInstances();
+    expect(blocked.size).toBe(2);
+    expect(blocked.has("spam.example.com")).toBe(true);
+    expect(blocked.has("bad.instance")).toBe(true);
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { getBlockedInstances, parseConfig, loadConfig } from "../config.js";
 import { join } from "node:path";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,3 +27,18 @@ export function parseConfig(yaml: string): FeedsConfig {
   const data = parseYaml(yaml);
   return FeedsConfigSchema.parse(data);
 }
+
+/**
+ * Returns the set of blocked instance hostnames (lowercase) from env
+ * BLOCKED_INSTANCES (comma-separated). Used to Reject Follow from those instances.
+ */
+export function getBlockedInstances(): Set<string> {
+  const raw = process.env.BLOCKED_INSTANCES;
+  if (!raw || typeof raw !== "string") return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((h) => h.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -7,7 +7,7 @@ import {
   type KvStore,
   type MessageQueue,
 } from "@fedify/fedify";
-import { Accept, Application, Follow, Undo } from "@fedify/vocab";
+import { Accept, Application, Follow, Reject, Undo } from "@fedify/vocab";
 import type { FeedsConfig } from "./config.js";
 import {
   addFollower,
@@ -26,10 +26,12 @@ export interface FederationDeps {
   db: Db;
   kvStore: KvStore;
   messageQueue: MessageQueue;
+  /** Blocked instance hostnames (lowercase); Follow from these gets Reject. */
+  blockedInstances?: Set<string>;
 }
 
 export function setupFederation(deps: FederationDeps): Federation<void> {
-  const { config, db, kvStore, messageQueue } = deps;
+  const { config, db, kvStore, messageQueue, blockedInstances = new Set() } = deps;
   const botUsernames = Object.keys(config.bots);
 
   const fed = createFederation<void>({
@@ -134,6 +136,22 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
     },
   );
 
+  fed.setNodeInfoDispatcher("/nodeinfo/2.1", async () => {
+    let localPosts = 0;
+    for (const identifier of botUsernames) {
+      localPosts += await countEntries(db, identifier);
+    }
+    return {
+      software: { name: "robot-villas", version: "1.0.0" },
+      protocols: ["activitypub"],
+      usage: {
+        users: { total: botUsernames.length },
+        localPosts,
+        localComments: 0,
+      },
+    };
+  });
+
   fed
     .setInboxListeners("/users/{identifier}/inbox", "/inbox")
     .on(Follow, async (ctx, follow) => {
@@ -143,6 +161,15 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
         return;
       const follower = await follow.getActor(ctx);
       if (!follower?.id) return;
+      const followerHost = follower.id.hostname.toLowerCase();
+      if (blockedInstances.has(followerHost)) {
+        await ctx.sendActivity(
+          { identifier: parsed.identifier },
+          follower,
+          new Reject({ actor: follow.objectId, object: follow }),
+        );
+        return;
+      }
       await addFollower(
         db,
         parsed.identifier,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "@hono/node-server";
 import { PostgresKvStore, PostgresMessageQueue } from "@fedify/postgres";
 import postgres from "postgres";
-import { loadConfig } from "./config.js";
+import { getBlockedInstances, loadConfig } from "./config.js";
 import { createDb, migrate } from "./db.js";
 import { setupFederation } from "./federation.js";
 import { startPoller } from "./poller.js";
@@ -31,8 +31,9 @@ await migrate(db);
 const kvStore = new PostgresKvStore(sql);
 const messageQueue = new PostgresMessageQueue(sql);
 
-const fed = setupFederation({ config, db, kvStore, messageQueue });
-const app = createApp(fed);
+const blockedInstances = getBlockedInstances();
+const fed = setupFederation({ config, db, kvStore, messageQueue, blockedInstances });
+const app = createApp(fed, config, DOMAIN);
 
 const server = serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`robot.villas listening on http://localhost:${info.port}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,13 +1,54 @@
 import { Hono } from "hono";
 import { federation as fedifyMiddleware } from "@fedify/hono";
 import type { Federation } from "@fedify/fedify";
+import type { FeedsConfig } from "./config.js";
 
-export function createApp(fed: Federation<void>): Hono {
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function createApp(
+  fed: Federation<void>,
+  config: FeedsConfig,
+  domain: string,
+): Hono {
   const app = new Hono();
 
   app.use(fedifyMiddleware(fed, () => undefined));
 
   app.get("/healthcheck", (c) => c.text("ok"));
+
+  app.get("/", (c) => {
+    const botList = Object.entries(config.bots)
+      .map(
+        ([username, bot]) =>
+          `<li><a href="https://${domain}/users/${escapeHtml(username)}">@${escapeHtml(username)}</a> – ${escapeHtml(bot.display_name)}</li>`,
+      )
+      .join("\n");
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(domain)}</title>
+</head>
+<body>
+  <h1>${escapeHtml(domain)}</h1>
+  <p>This is an <strong>RSS-to-Mastodon bridge</strong>. Each bot account mirrors an RSS feed; you can follow them from any Mastodon or ActivityPub-compatible server.</p>
+  <h2>Bots</h2>
+  <ul>
+${botList}
+  </ul>
+  <p><a href="https://github.com/icco/robot.villas">Source code</a></p>
+</body>
+</html>`;
+    return c.html(html);
+  });
 
   return app;
 }


### PR DESCRIPTION
Implements **Work tree 2** (Mastodon best practices & compliance) from the audit plan.

## Changes

1. **Block list + Reject on Follow**
   - `BLOCKED_INSTANCES` env: comma-separated instance hostnames (e.g. `spam.example,bad.example`).
   - When a Follow comes from an actor whose hostname is in the block list, we send `Reject` and do not add the follower.
   - `getBlockedInstances()` in config; README documents the variable.

2. **NodeInfo**
   - `fed.setNodeInfoDispatcher("/nodeinfo/2.1", ...)` so `/.well-known/nodeinfo` and `/nodeinfo/2.1` expose:
     - `software`: name `robot-villas`, version `1.0.0`
     - `protocols`: `["activitypub"]`
     - `usage`: users total (bot count), localPosts (sum of entries), localComments 0.
   - Reduces "unknown server" blocks by other instances.

3. **Landing page**
   - `GET /` serves a simple HTML page: instance name, short description (RSS-to-Mastodon bridge), list of bots with links to their profile URLs, link to source.
   - Helps admins identify the instance and reduces mistaken blocks.

## Tests

- `getBlockedInstances()`: empty when unset, parses comma-separated and lowercases hostnames.

Ref: Two-work-tree audit plan (other work tree = compliance).