### PR TITLE
feat: add profile photos and bot profile pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,22 @@ bots:
     feed_url: "https://news.ycombinator.com/rss"
     display_name: "Hacker News"
     summary: "Top stories from Hacker News"
+    profile_photo: "https://news.ycombinator.com/y18.svg"
   lobsters:
     feed_url: "https://lobste.rs/rss"
     display_name: "Lobsters"
     summary: "Stories from Lobsters"
+    profile_photo: "https://lobste.rs/apple-touch-icon-144.png"
 ```
 
 Each key under `bots` becomes the bot's username on the instance. Usernames must be lowercase alphanumeric or underscores (validated at startup via Zod).
+
+| Field | Required | Description |
+|---|---|---|
+| `feed_url` | Yes | URL of the RSS/Atom feed |
+| `display_name` | Yes | Display name shown on the profile (max 100 chars) |
+| `summary` | Yes | Short bio/description (max 500 chars) |
+| `profile_photo` | No | URL to an avatar image, used as the ActivityPub actor icon and shown on the profile page |
 
 ## Tech Stack
 
@@ -98,7 +107,7 @@ src/
   federation.ts     Fedify federation, actor dispatchers, inbox listeners
   publisher.ts      Dedup + publish new entries as Create(Note) activities
   poller.ts         Interval-based polling loop
-  server.ts         Hono app with Fedify middleware and healthcheck
+  server.ts         Hono app with Fedify middleware, homepage, and bot profile pages
   __tests__/        Unit and integration tests
 drizzle/            Generated SQL migration files (committed to git)
 ```
@@ -117,6 +126,7 @@ drizzle/            Generated SQL migration files (committed to git)
 - Add a new entry under `bots:` in `feeds.yml`. The key becomes the bot's fediverse username (e.g. `lobsters` -> `@lobsters@robot.villas`).
 - Usernames must be lowercase alphanumeric or underscores -- this is enforced by Zod validation at startup.
 - Provide a meaningful `display_name` and `summary` -- these appear on the bot's fediverse profile.
+- Optionally set `profile_photo` to a URL pointing to an avatar image. This is served as the ActivityPub actor `icon` (visible in Mastodon etc.) and displayed on the bot's HTML profile page at `/@username`.
 - No restart is needed for key generation; key pairs are created lazily on first actor dispatch and persisted in the `actor_keypairs` table.
 
 ### Fedify v2 Notes

--- a/feeds.yml
+++ b/feeds.yml
@@ -3,7 +3,9 @@ bots:
     feed_url: "https://news.ycombinator.com/rss"
     display_name: "Hacker News"
     summary: "Top stories from Hacker News"
+    profile_photo: "https://news.ycombinator.com/y18.svg"
   lobsters:
     feed_url: "https://lobste.rs/rss"
     display_name: "Lobsters"
     summary: "Stories from Lobsters"
+    profile_photo: "https://lobste.rs/apple-touch-icon-144.png"

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -15,6 +15,32 @@ bots:
     expect(config.bots.hackernews.feed_url).toBe("https://news.ycombinator.com/rss");
     expect(config.bots.hackernews.display_name).toBe("Hacker News");
     expect(config.bots.hackernews.summary).toBe("Top stories from Hacker News");
+    expect(config.bots.hackernews.profile_photo).toBeUndefined();
+  });
+
+  it("parses config with profile_photo", () => {
+    const config = parseConfig(`
+bots:
+  hackernews:
+    feed_url: "https://news.ycombinator.com/rss"
+    display_name: "Hacker News"
+    summary: "Top stories from Hacker News"
+    profile_photo: "https://example.com/photo.png"
+`);
+    expect(config.bots.hackernews.profile_photo).toBe("https://example.com/photo.png");
+  });
+
+  it("rejects config with invalid profile_photo URL", () => {
+    expect(() =>
+      parseConfig(`
+bots:
+  test:
+    feed_url: "https://example.com/rss"
+    display_name: "Test"
+    summary: "A bot"
+    profile_photo: "not-a-url"
+`),
+    ).toThrow();
   });
 
   it("parses multiple bots", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const BotSchema = z.object({
   feed_url: z.string().url(),
   display_name: z.string().min(1).max(MAX_DISPLAY_NAME_LENGTH),
   summary: z.string().min(1).max(MAX_SUMMARY_LENGTH),
+  profile_photo: z.string().url().optional(),
 });
 
 export const FeedsConfigSchema = z.object({

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -7,7 +7,7 @@ import {
   type KvStore,
   type MessageQueue,
 } from "@fedify/fedify";
-import { Accept, Application, Follow, Reject, Undo } from "@fedify/vocab";
+import { Accept, Application, Follow, Image, Reject, Undo } from "@fedify/vocab";
 import type { FeedsConfig } from "./config.js";
 import {
   addFollower,
@@ -48,6 +48,9 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
         preferredUsername: identifier,
         name: bot.display_name,
         summary: bot.summary,
+        icon: bot.profile_photo
+          ? new Image({ url: new URL(bot.profile_photo) })
+          : null,
         inbox: ctx.getInboxUri(identifier),
         outbox: ctx.getOutboxUri(identifier),
         url: new URL(`/users/${identifier}`, ctx.url),

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const messageQueue = new PostgresMessageQueue(sql);
 
 const blockedInstances = getBlockedInstances();
 const fed = setupFederation({ config, db, kvStore, messageQueue, blockedInstances });
-const app = createApp(fed, config, DOMAIN);
+const app = createApp(fed, config, DOMAIN, db);
 
 const server = serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`robot.villas listening on http://localhost:${info.port}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,8 +59,8 @@ ${botList}
   });
 
   app.get("/@:username", async (c) => {
-    const username = c.req.param("username");
-    if (!config.bots[username]) return c.notFound();
+    const username = c.req.param("username") as string;
+    if (!(username in config.bots)) return c.notFound();
 
     const bot = config.bots[username];
     const page = parseInt(c.req.query("page") || "0", 10);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { federation as fedifyMiddleware } from "@fedify/hono";
 import type { Federation } from "@fedify/fedify";
 import type { FeedsConfig } from "./config.js";
+import { countEntries, getEntriesPage, type Db } from "./db.js";
 
 function escapeHtml(s: string): string {
   return s
@@ -12,10 +13,13 @@ function escapeHtml(s: string): string {
     .replace(/'/g, "&#39;");
 }
 
+const PROFILE_PAGE_SIZE = 40;
+
 export function createApp(
   fed: Federation<void>,
   config: FeedsConfig,
   domain: string,
+  db: Db,
 ): Hono {
   const app = new Hono();
 
@@ -26,8 +30,12 @@ export function createApp(
   app.get("/", (c) => {
     const botList = Object.entries(config.bots)
       .map(
-        ([username, bot]) =>
-          `<li><a href="https://${domain}/users/${escapeHtml(username)}">@${escapeHtml(username)}</a> – ${escapeHtml(bot.display_name)}</li>`,
+        ([username, bot]) => {
+          const photoHtml = bot.profile_photo
+            ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="24" height="24" style="vertical-align:middle;border-radius:50%;margin-right:6px">`
+            : "";
+          return `<li>${photoHtml}<a href="/@${escapeHtml(username)}">@${escapeHtml(username)}</a> – ${escapeHtml(bot.display_name)}</li>`;
+        },
       )
       .join("\n");
     const html = `<!DOCTYPE html>
@@ -45,6 +53,63 @@ export function createApp(
 ${botList}
   </ul>
   <p><a href="https://github.com/icco/robot.villas">Source code</a></p>
+</body>
+</html>`;
+    return c.html(html);
+  });
+
+  app.get("/@:username", async (c) => {
+    const username = c.req.param("username");
+    if (!config.bots[username]) return c.notFound();
+
+    const bot = config.bots[username];
+    const page = parseInt(c.req.query("page") || "0", 10);
+    const offset = Math.max(0, page) * PROFILE_PAGE_SIZE;
+    const total = await countEntries(db, username);
+    const entries = await getEntriesPage(db, username, PROFILE_PAGE_SIZE, offset);
+    const hasNext = offset + entries.length < total;
+    const hasPrev = offset > 0;
+
+    const photoHtml = bot.profile_photo
+      ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="96" height="96" style="border-radius:50%">`
+      : "";
+
+    const entriesHtml = entries.length > 0
+      ? entries.map((entry) => {
+          const date = entry.publishedAt
+            ? `<time datetime="${entry.publishedAt.toISOString()}">${entry.publishedAt.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}</time>`
+            : "";
+          const link = entry.url
+            ? `<a href="${escapeHtml(entry.url)}">${escapeHtml(entry.title)}</a>`
+            : escapeHtml(entry.title);
+          return `<li>${link}${date ? ` <small>${date}</small>` : ""}</li>`;
+        }).join("\n")
+      : "<li><em>No posts yet.</em></li>";
+
+    const paginationHtml = (hasPrev || hasNext)
+      ? `<nav style="margin-top:1em">${hasPrev ? `<a href="/@${escapeHtml(username)}?page=${page - 1}">&laquo; Newer</a>` : ""}${hasPrev && hasNext ? " | " : ""}${hasNext ? `<a href="/@${escapeHtml(username)}?page=${page + 1}">Older &raquo;</a>` : ""}</nav>`
+      : "";
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>@${escapeHtml(username)}@${escapeHtml(domain)}</title>
+</head>
+<body>
+  <header>
+    ${photoHtml}
+    <h1>${escapeHtml(bot.display_name)}</h1>
+    <p><code>@${escapeHtml(username)}@${escapeHtml(domain)}</code></p>
+    <p>${escapeHtml(bot.summary)}</p>
+  </header>
+  <h2>Posts</h2>
+  <ul>
+${entriesHtml}
+  </ul>
+  ${paginationHtml}
+  <p style="margin-top:2em"><a href="/">&larr; All bots</a></p>
 </body>
 </html>`;
     return c.html(html);


### PR DESCRIPTION
## Summary
- Adds an optional `profile_photo` URL field to the bot YAML config, validated as a URL by Zod
- Sets the ActivityPub actor `icon` (via Fedify `Image`) so avatars appear in Mastodon and other AP clients
- Adds an `/@username` HTML profile page showing the bot's photo, display name, summary, and a paginated list of posts
- Updates the homepage bot list to link to profile pages and show avatar thumbnails

## Test plan
- [x] All existing tests pass (`npx vitest run` — 35 passed)
- [x] New config tests: `profile_photo` is optional, parses valid URLs, rejects invalid URLs
- [ ] Verify profile page renders correctly with a running instance
- [ ] Verify ActivityPub actor JSON includes `icon` when `profile_photo` is set

Made with [Cursor](https://cursor.com)