### PR TITLE
fix: point actor url to profile page to prevent redirect loop

### DIFF
--- a/src/federation.ts
+++ b/src/federation.ts
@@ -59,7 +59,7 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
         endpoints: new Endpoints({
           sharedInbox: ctx.getInboxUri(),
         }),
-        url: new URL(`/users/${identifier}`, ctx.url),
+        url: new URL(`/@${identifier}`, ctx.url),
         publicKeys: keys.map((kp) => kp.cryptographicKey),
         assertionMethods: keys.map((kp) => kp.multikey),
       });


### PR DESCRIPTION
## Summary
- The ActivityPub actor's `url` property was set to `/users/{identifier}` — the same path as the actor endpoint itself. When a browser visited `/users/lobsters` or `/users/hackernews`, Fedify's content negotiation redirected to `url`, which looped back to the same path infinitely.
- Changed `url` to `/@{identifier}` so browser requests to `/users/{identifier}` now redirect to the `/@{identifier}` HTML profile page served by Hono.

## Test plan
- [x] All existing tests pass (35 passed, 9 skipped)
- [ ] Visit `/users/lobsters` in a browser — should redirect to `/@lobsters` profile page
- [ ] Visit `/users/hackernews` in a browser — should redirect to `/@hackernews` profile page
- [ ] Verify ActivityPub clients still receive JSON from `/users/{identifier}` (content negotiation)

Made with [Cursor](https://cursor.com)