### PR TITLE
fix: resolve federation interop issues preventing follows and post visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@js-temporal/polyfill": "^0.5.1",
     "@logtape/logtape": "^2.0.2",
     "drizzle-orm": "^0.45.1",
+    "escape-html": "^1.0.3",
     "hono": "^4.6.0",
     "js-yaml": "^4.1.0",
     "postgres": "^3.4.0",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/escape-html": "^1.0.4",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.0",
     "drizzle-kit": "^0.31.9",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "js-yaml": "^4.1.0",
     "postgres": "^3.4.0",
     "rss-parser": "^3.13.0",
+    "x-forwarded-fetch": "^0.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/db.ts
+++ b/src/db.ts
@@ -77,6 +77,24 @@ export async function countEntries(db: Db, botUsername: string): Promise<number>
   return rows[0]?.value ?? 0;
 }
 
+export async function getEntryById(
+  db: Db,
+  botUsername: string,
+  entryId: number,
+): Promise<{ id: number; url: string; title: string; publishedAt: Date | null } | null> {
+  const rows = await db
+    .select({
+      id: schema.feedEntries.id,
+      url: schema.feedEntries.url,
+      title: schema.feedEntries.title,
+      publishedAt: schema.feedEntries.publishedAt,
+    })
+    .from(schema.feedEntries)
+    .where(and(eq(schema.feedEntries.botUsername, botUsername), eq(schema.feedEntries.id, entryId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
 export async function getEntriesPage(
   db: Db,
   botUsername: string,

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -8,19 +8,21 @@ import {
   type MessageQueue,
 } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
-import { Accept, Application, Endpoints, Follow, Image, Reject, Undo } from "@fedify/vocab";
+import { Temporal } from "@js-temporal/polyfill";
+import { Accept, Application, Endpoints, Follow, Image, Note, PUBLIC_COLLECTION, Reject, Undo } from "@fedify/vocab";
 import type { FeedsConfig } from "./config.js";
 import {
   addFollower,
   countEntries,
   getEntriesPage,
+  getEntryById,
   getFollowers,
   getKeypairs,
   removeFollower,
   saveKeypairs,
   type Db,
 } from "./db.js";
-import { buildCreateActivity } from "./publisher.js";
+import { buildCreateActivity, escapeHtml, safeParseUrl } from "./publisher.js";
 
 export interface FederationDeps {
   config: FeedsConfig;
@@ -63,10 +65,11 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
           sharedInbox: ctx.getInboxUri(),
         }),
         url: new URL(`/@${identifier}`, ctx.url),
-        publicKeys: keys.map((kp) => kp.cryptographicKey),
+        publicKey: keys[0].cryptographicKey,
         assertionMethods: keys.map((kp) => kp.multikey),
       });
     })
+    .mapHandle((_ctx, handle) => handle)
     .setKeyPairsDispatcher(async (_ctx, identifier) => {
       if (!botUsernames.includes(identifier)) return [];
       const existing = await getKeypairs(db, identifier);
@@ -145,6 +148,33 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
         Math.floor((total - 1) / OUTBOX_PAGE_SIZE) * OUTBOX_PAGE_SIZE;
       return String(lastOffset);
     });
+
+  fed.setObjectDispatcher(
+    Note,
+    "/users/{identifier}/posts/{id}",
+    async (ctx, values) => {
+      const { identifier, id } = values;
+      if (!botUsernames.includes(identifier)) return null;
+      const entryId = parseInt(id, 10);
+      if (Number.isNaN(entryId)) return null;
+      const entry = await getEntryById(db, identifier, entryId);
+      if (!entry) return null;
+      const content = `<p>${escapeHtml(entry.title)}</p>` +
+        (entry.url ? `<p><a href="${escapeHtml(entry.url)}">${escapeHtml(entry.url)}</a></p>` : "");
+      return new Note({
+        id: ctx.getObjectUri(Note, values),
+        attribution: ctx.getActorUri(identifier),
+        to: PUBLIC_COLLECTION,
+        cc: ctx.getFollowersUri(identifier),
+        content,
+        mediaType: "text/html",
+        url: safeParseUrl(entry.url),
+        published: entry.publishedAt
+          ? Temporal.Instant.from(entry.publishedAt.toISOString())
+          : undefined,
+      });
+    },
+  );
 
   fed.setFollowersDispatcher(
     "/users/{identifier}/followers",

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -22,7 +22,8 @@ import {
   saveKeypairs,
   type Db,
 } from "./db.js";
-import { buildCreateActivity, escapeHtml, safeParseUrl } from "./publisher.js";
+import escapeHtml from "escape-html";
+import { buildCreateActivity, safeParseUrl } from "./publisher.js";
 
 export interface FederationDeps {
   config: FeedsConfig;

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,6 +1,7 @@
 import { Temporal } from "@js-temporal/polyfill";
 import type { Context } from "@fedify/fedify";
 import { Create, Note, PUBLIC_COLLECTION } from "@fedify/vocab";
+import escapeHtml from "escape-html";
 import { getFollowers, insertEntry, type Db } from "./db.js";
 import type { FeedEntry } from "./rss.js";
 
@@ -134,13 +135,4 @@ function formatContent(entry: EntryLike): string {
     return `<p>${escapeHtml(entry.title)}</p><p><a href="${escapeHtml(href)}">${escapeHtml(href)}</a></p>`;
   }
   return `<p>${escapeHtml(entry.title)}</p>`;
-}
-
-export function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,6 +1,6 @@
 import { Temporal } from "@js-temporal/polyfill";
 import type { Context } from "@fedify/fedify";
-import { Create, Note } from "@fedify/vocab";
+import { Create, Note, PUBLIC_COLLECTION } from "@fedify/vocab";
 import { getFollowers, insertEntry, type Db } from "./db.js";
 import type { FeedEntry } from "./rss.js";
 
@@ -33,11 +33,15 @@ export function buildCreateActivity(
 ): Create {
   const noteId = new URL(`/users/${botUsername}/posts/${entryId}`, baseUrl);
   const actorId = new URL(`/users/${botUsername}`, baseUrl);
+  const followersId = new URL(`/users/${botUsername}/followers`, baseUrl);
 
   const note = new Note({
     id: noteId,
     attribution: actorId,
+    to: PUBLIC_COLLECTION,
+    cc: followersId,
     content: formatContent(entry),
+    mediaType: "text/html",
     url: safeParseUrl(entry.link),
     published: entry.publishedAt
       ? Temporal.Instant.from(entry.publishedAt.toISOString())
@@ -48,6 +52,8 @@ export function buildCreateActivity(
     id: new URL(`${noteId.href}#activity`),
     actor: actorId,
     object: note,
+    tos: [PUBLIC_COLLECTION],
+    ccs: [followersId],
   });
 }
 
@@ -130,7 +136,7 @@ function formatContent(entry: EntryLike): string {
   return `<p>${escapeHtml(entry.title)}</p>`;
 }
 
-function escapeHtml(s: string): string {
+export function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,9 @@
 import { Hono } from "hono";
 import { federation as fedifyMiddleware } from "@fedify/hono";
 import type { Federation } from "@fedify/fedify";
+import escapeHtml from "escape-html";
 import type { FeedsConfig } from "./config.js";
 import { countEntries, getEntriesPage, type Db } from "./db.js";
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
 
 const PROFILE_PAGE_SIZE = 40;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,12 @@ ${botList}
     return c.html(html);
   });
 
+  app.get("/users/:username", (c) => {
+    const username = c.req.param("username") as string;
+    if (!(username in config.bots)) return c.notFound();
+    return c.redirect(`/@${username}`);
+  });
+
   app.get("/@:username", async (c) => {
     const username = c.req.param("username") as string;
     if (!(username in config.bots)) return c.notFound();

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,6 +779,11 @@
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
+"@types/escape-html@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.4.tgz#dc7c166b76c7b03b27e32f80edf01d91eb5d9af2"
+  integrity sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==
+
 "@types/esrecurse@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/esrecurse/-/esrecurse-4.3.1.tgz#6f636af962fbe6191b830bd676ba5986926bccec"
@@ -1190,6 +1195,11 @@ esbuild@~0.18.20:
     "@esbuild/win32-arm64" "0.18.20"
     "@esbuild/win32-ia32" "0.18.20"
     "@esbuild/win32-x64" "0.18.20"
+
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,6 +1918,11 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+x-forwarded-fetch@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/x-forwarded-fetch/-/x-forwarded-fetch-0.2.0.tgz#6710d3e28705fa1c08518a1b4730cd18ccd4965b"
+  integrity sha512-2qsguQrLHFvP3/rnvxSSaw3DlK9eOOx9iyL+Qv+1YH8jzq6nbRk+P6gyFFNdWanyusyCHuE3/CnX3+gmLeYEeg==
+
 xml2js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"


### PR DESCRIPTION
## Summary

- **Add `behindProxy()` wrapper** — behind the reverse proxy, all Fedify-generated URIs used `http://` instead of `https://`, causing every HTTP Signature to have mismatched key IDs. Mastodon rejected all signed activities (`Accept(Follow)`, `Create(Note)`, etc.), so follows silently failed and posts never delivered.
- **Use singular `publicKey` instead of plural `publicKeys`** — Mastodon (and most implementations) only read the singular `publicKey` property for HTTP Signature verification. The [Fedify docs](https://unstable.fedify.dev/manual/actor) explicitly recommend this.
- **Add `to: PUBLIC_COLLECTION` and `cc: followersUri` on Notes, `tos`/`ccs` on Create activities** — without these, Mastodon treated every post as a direct message and hid them from timelines.
- **Add `mediaType: "text/html"` on Notes** — without it, Mastodon rendered raw HTML tags as plain text.
- **Add `setObjectDispatcher` for `Note`** — Note URIs (`/users/{id}/posts/{id}`) were not dereferenceable, breaking search and discovery.
- **Add `mapHandle()` to actor dispatcher** — suppresses the `ERR`-level "No actor handle mapper" log.
- **Add `/users/:username` HTML redirect to `/@:username`** — fixes 406 errors when browsers visit actor URIs directly.

## Test plan

- [ ] Deploy and verify `https://robot.villas/@hackernews` no longer returns 404
- [ ] Verify WebFinger lookup: `curl https://robot.villas/.well-known/webfinger?resource=acct:hackernews@robot.villas` returns correct `https://` URIs
- [ ] Verify actor JSON: `curl -H"Accept: application/activity+json" https://robot.villas/users/hackernews` shows singular `publicKey` and correct `https://` URIs
- [ ] Search for `@hackernews@robot.villas` on a Mastodon instance and verify the bot appears
- [ ] Follow a bot from Mastodon and verify the follow is accepted (check logs for `Accept` activity)
- [ ] Verify new posts appear in followers' timelines after the next poll cycle
- [ ] Verify Note URIs are dereferenceable: `curl -H"Accept: application/activity+json" https://robot.villas/users/hackernews/posts/1`
- [ ] Verify browser visits to `/users/hackernews` redirect to `/@hackernews` (no more 406)

Made with [Cursor](https://cursor.com)