### PR TITLE
feat: add shared layout with Tailwind v4 + daisyUI

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -194,6 +194,11 @@ bots:
     display_name: Ars Technica
     summary: In-depth technology, science, and culture reporting.
     profile_photo: https://cdn.arstechnica.net/wp-content/uploads/2016/10/cropped-ars-logo-512_480.png
+  bandcamp_daily:
+    feed_url: https://daily.bandcamp.com/feed
+    display_name: Bandcamp Daily
+    summary: Music discovery, artist features, and deep dives from Bandcamp.
+    profile_photo: https://s4.bcbits.com/img/favicon/apple-touch-icon.png
 follows:
   - '@icco@merveilles.town'
 relays:

--- a/feeds.yml
+++ b/feeds.yml
@@ -27,6 +27,7 @@ bots:
     feed_url: https://writing.natwelch.com/feed.atom
     display_name: Nat? Nat. Nat!
     summary: Nat Welch's blog about random stuff.
+    profile_photo: https://avatars.githubusercontent.com/u/20201?s=200
   chronogram:
     feed_url: https://www.chronogram.com/feed/
     display_name: Chronogram Magazine
@@ -71,14 +72,17 @@ bots:
     feed_url: https://eli.thegreenplace.net/feeds/all.atom.xml
     display_name: Eli Bendersky
     summary: Articles from Eli Bendersky's website.
+    profile_photo: https://avatars.githubusercontent.com/u/383822?s=200
   danluu:
     feed_url: https://danluu.com/atom.xml
     display_name: Dan Luu
     summary: Articles from Dan Luu.
+    profile_photo: https://avatars.githubusercontent.com/u/157136?s=200
   julia_evans:
     feed_url: https://jvns.ca/atom.xml
     display_name: Julia Evans
     summary: Blog posts from Julia Evans.
+    profile_photo: https://avatars.githubusercontent.com/u/817739?s=200
   marc_dougherty:
     feed_url: https://www.marcdougherty.com/index.xml
     display_name: Marc Dougherty
@@ -93,6 +97,7 @@ bots:
     feed_url: https://purplesyringa.moe/blog/feed.rss
     display_name: purplesyringa's blog
     summary: Posts from purplesyringa's blog.
+    profile_photo: https://avatars.githubusercontent.com/u/16370781?s=200
   spotify_engineering:
     feed_url: https://engineering.atspotify.com/feed
     display_name: Spotify Engineering
@@ -111,10 +116,12 @@ bots:
     feed_url: https://blog.cloudflare.com/rss/
     display_name: Cloudflare Blog
     summary: Deep dives into networking, security, and systems engineering.
+    profile_photo: https://blog.cloudflare.com/images/favicon-32x32.png
   brandur:
     feed_url: https://brandur.org/articles.atom
     display_name: Brandur Leach
     summary: High-quality writing on Postgres, distributed systems, and API design.
+    profile_photo: https://brandur.org/assets/images/favicon/favicon-256.jpg
   orbital_index:
     feed_url: https://orbitalindex.com/feed.xml
     display_name: The Orbital Index
@@ -123,31 +130,37 @@ bots:
     feed_url: https://www.quantamagazine.org/feed/
     display_name: Quanta Magazine
     summary: Illuminating science and mathematics through public-service journalism.
+    profile_photo: https://www.quantamagazine.org/wp-content/themes/quanta2024/frontend/images/apple-touch-icon.png
   low_tech:
     feed_url: https://solar.lowtechmagazine.com/posts/index.xml
     display_name: Low-tech Magazine
     summary: A solar-powered blog about sustainable and historical technology.
+    profile_photo: https://solar.lowtechmagazine.com/icons/sun.svg
   tigerbeetle:
     feed_url: https://tigerbeetle.com/blog/atom.xml
     display_name: TigerBeetle
     summary: Engineering a high-performance, safety-critical financial database.
+    profile_photo: https://framerusercontent.com/images/GMJ8d83FjKzitkLWA3knVLO5HQ.png
   false_knees:
     feed_url: https://falseknees.com/rss.xml
     display_name: False Knees
     summary: Comics about birds and animals having existential crises.
+    profile_photo: https://falseknees.com/assets/favicon.webp
   kottke:
     feed_url: https://feeds.kottke.org/main
     display_name: kottke.org
     summary: Home of fine hypertext products since 1998.
+    profile_photo: https://kottke.org/images/2024/icons/256x256.png
   nelson_elhage:
     feed_url: https://blog.nelhage.com/atom.xml
     display_name: Nelson Elhage
     summary: Blog posts on systems, compilers, and performance.
+    profile_photo: https://avatars.githubusercontent.com/u/220198?s=200
   simon_willison:
     feed_url: https://simonwillison.net/atom/everything/
     display_name: Simon Willison
     summary: Creator of Datasette, writing about AI, Python, and open source tools.
-    profile_photo: https://simonwillison.net/favicon.ico
+    profile_photo: https://avatars.githubusercontent.com/u/9599?s=200
   rachel_by_the_bay:
     feed_url: https://rachelbythebay.com/w/atom.xml
     display_name: Rachel by the Bay
@@ -180,7 +193,7 @@ bots:
     feed_url: https://arstechnica.com/feed/
     display_name: Ars Technica
     summary: In-depth technology, science, and culture reporting.
-    profile_photo: https://cdn.arstechnica.net/wp-content/uploads/2016/10/cropped-ars-logo-512_480-32x32.png
+    profile_photo: https://cdn.arstechnica.net/wp-content/uploads/2016/10/cropped-ars-logo-512_480.png
 follows:
   - '@icco@merveilles.town'
 relays:

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -17,11 +17,11 @@ export function layout(opts: {
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
   <style type="text/tailwindcss">
     @theme {
-      --font-display: "Space Mono", monospace;
-      --font-body: "DM Sans", sans-serif;
+      --font-display: "Roboto Mono", monospace;
+      --font-body: "Roboto", sans-serif;
     }
   </style>
   ${opts.extraHead ?? ""}

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,0 +1,52 @@
+import escapeHtml from "escape-html";
+
+export function layout(opts: {
+  title: string;
+  domain: string;
+  content: string;
+  extraHead?: string;
+}): string {
+  return `<!DOCTYPE html>
+<html lang="en" data-theme="dim">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(opts.title)}</title>
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@5/themes.css" rel="stylesheet" type="text/css" />
+  <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style type="text/tailwindcss">
+    @theme {
+      --font-display: "Space Mono", monospace;
+      --font-body: "DM Sans", sans-serif;
+    }
+  </style>
+  ${opts.extraHead ?? ""}
+</head>
+<body class="min-h-screen flex flex-col bg-base-100 font-body">
+  <header class="navbar bg-base-200 border-b border-base-300">
+    <div class="container mx-auto">
+      <a href="/" class="text-xl font-display font-bold tracking-tight hover:opacity-80 transition-opacity flex items-center gap-2">
+        <span class="text-2xl">🤖</span>
+        <span>${escapeHtml(opts.domain)}</span>
+      </a>
+    </div>
+  </header>
+  <main class="container mx-auto flex-1 px-4 py-8 max-w-4xl">
+    ${opts.content}
+  </main>
+  <footer class="footer sm:footer-horizontal footer-center bg-base-200 border-t border-base-300 text-base-content p-6 text-sm">
+    <nav class="flex flex-wrap justify-center gap-x-1">
+      <span>&copy; <a href="https://natwelch.com" class="link link-hover">Nat Welch</a></span>
+      <span>·</span>
+      <a href="https://github.com/icco/robot.villas" class="link link-hover">Source code</a>
+      <span>·</span>
+      <a href="https://github.com/icco/robot.villas/edit/main/feeds.yml" class="link link-hover">Add or update a feed</a>
+    </nav>
+  </footer>
+</body>
+</html>`;
+}

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -12,6 +12,7 @@ export function layout(opts: {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(opts.title)}</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🤖</text></svg>">
   <link href="https://cdn.jsdelivr.net/npm/daisyui@5/themes.css" rel="stylesheet" type="text/css" />
   <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ export function createApp(
 
   app.get("/", (c) => {
     const botList = Object.entries(config.bots)
+      .sort(([a], [b]) => a.localeCompare(b))
       .map(([username, bot]) => {
         const photoHtml = bot.profile_photo
           ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="24" height="24" class="rounded-full">`

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,10 +48,10 @@ export function createApp(
       <div class="card bg-base-200 mb-8">
         <div class="card-body">
           <h3 class="card-title font-display text-lg">How it works</h3>
-          <ol class="steps steps-vertical text-sm">
-            <li class="step step-primary">Pick a bot from the list below.</li>
-            <li class="step step-primary">Search for its handle (e.g. <code class="badge badge-sm font-mono">@hackernews@${escapeHtml(domain)}</code>) on your Mastodon instance, or click "Follow on Mastodon" on its profile page.</li>
-            <li class="step step-primary">New items from the RSS feed will appear in your home timeline.</li>
+          <ol class="list-decimal list-inside space-y-2 text-sm text-base-content/80">
+            <li>Pick a bot from the list below.</li>
+            <li>Search for its handle (e.g. <code class="bg-base-300 px-1.5 py-0.5 rounded font-mono text-xs">@hackernews@${escapeHtml(domain)}</code>) on your Mastodon instance, or click "Follow on Mastodon" on its profile page.</li>
+            <li>New items from the RSS feed will appear in your home timeline.</li>
           </ol>
         </div>
       </div>

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type { Federation } from "@fedify/fedify";
 import escapeHtml from "escape-html";
 import type { FeedsConfig } from "./config.js";
 import { countEntries, countFollowers, getEntriesPage, type Db } from "./db.js";
+import { layout } from "./layout.js";
 
 const PROFILE_PAGE_SIZE = 40;
 
@@ -21,41 +22,49 @@ export function createApp(
 
   app.get("/", (c) => {
     const botList = Object.entries(config.bots)
-      .map(
-        ([username, bot]) => {
-          const photoHtml = bot.profile_photo
-            ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="24" height="24" style="vertical-align:middle;border-radius:50%;margin-right:6px">`
-            : "";
-          return `<li>${photoHtml}<a href="/@${escapeHtml(username)}">@${escapeHtml(username)}</a> – ${escapeHtml(bot.display_name)} <small style="color:#666">(${escapeHtml(bot.summary)})</small></li>`;
-        },
-      )
+      .map(([username, bot]) => {
+        const photoHtml = bot.profile_photo
+          ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="24" height="24" class="rounded-full">`
+          : `<div class="w-6 h-6 rounded-full bg-base-300 flex items-center justify-center text-xs">🤖</div>`;
+        return `<a href="/@${escapeHtml(username)}" class="flex items-center gap-3 p-3 rounded-lg hover:bg-base-200 transition-colors group">
+          ${photoHtml}
+          <div class="min-w-0">
+            <span class="font-mono text-sm font-semibold group-hover:text-primary transition-colors">@${escapeHtml(username)}</span>
+            <span class="text-base-content/60 mx-1">–</span>
+            <span class="font-medium">${escapeHtml(bot.display_name)}</span>
+            <p class="text-xs text-base-content/50 truncate">${escapeHtml(bot.summary)}</p>
+          </div>
+        </a>`;
+      })
       .join("\n");
-    const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${escapeHtml(domain)} – RSS-to-Mastodon Bridge</title>
-</head>
-<body>
-  <h1>${escapeHtml(domain)}</h1>
-  <p><strong>${escapeHtml(domain)}</strong> is an <strong>RSS-to-Mastodon bridge</strong>. It runs a collection of bot accounts, each mirroring a public RSS or Atom feed. New posts from each feed are automatically published as toots, so you can follow your favorite blogs, news sites, and newsletters directly from Mastodon or any ActivityPub-compatible server (Pleroma, Misskey, GoToSocial, etc.).</p>
-  <h3>How it works</h3>
-  <ol>
-    <li>Pick a bot from the list below.</li>
-    <li>Search for its handle (e.g. <code>@hackernews@${escapeHtml(domain)}</code>) on your Mastodon instance, or click "Follow on Mastodon" on its profile page.</li>
-    <li>New items from the RSS feed will appear in your home timeline.</li>
-  </ol>
-  <h2>Bots</h2>
-  <ul>
-${botList}
-  </ul>
-  <footer style="margin-top:2em;padding-top:1em;border-top:1px solid #ddd;font-size:0.85em;color:#666">
-    <p>&copy; <a href="https://natwelch.com">Nat Welch</a> · <a href="https://github.com/icco/robot.villas">Source code</a> · <a href="https://github.com/icco/robot.villas/edit/main/feeds.yml">Add or update a feed</a></p>
-  </footer>
-</body>
-</html>`;
-    return c.html(html);
+
+    const content = `
+      <div class="mb-8">
+        <h1 class="text-4xl font-display font-bold tracking-tight mb-4">${escapeHtml(domain)}</h1>
+        <p class="text-base-content/80 text-lg leading-relaxed max-w-2xl">
+          An <strong class="font-semibold">RSS-to-Mastodon bridge</strong>. A collection of bot accounts, each mirroring a public RSS or Atom feed. Follow your favorite blogs, news sites, and newsletters from Mastodon or any ActivityPub-compatible server.
+        </p>
+      </div>
+      <div class="card bg-base-200 mb-8">
+        <div class="card-body">
+          <h3 class="card-title font-display text-lg">How it works</h3>
+          <ol class="steps steps-vertical text-sm">
+            <li class="step step-primary">Pick a bot from the list below.</li>
+            <li class="step step-primary">Search for its handle (e.g. <code class="badge badge-sm font-mono">@hackernews@${escapeHtml(domain)}</code>) on your Mastodon instance, or click "Follow on Mastodon" on its profile page.</li>
+            <li class="step step-primary">New items from the RSS feed will appear in your home timeline.</li>
+          </ol>
+        </div>
+      </div>
+      <h2 class="text-2xl font-display font-bold mb-4">Bots</h2>
+      <div class="divide-y divide-base-300">
+        ${botList}
+      </div>`;
+
+    return c.html(layout({
+      title: `${domain} – RSS-to-Mastodon Bridge`,
+      domain,
+      content,
+    }));
   });
 
   app.get("/users/:username", (c) => {
@@ -82,60 +91,63 @@ ${botList}
     const hasPrev = offset > 0;
 
     const photoHtml = bot.profile_photo
-      ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="96" height="96" style="border-radius:50%">`
-      : "";
+      ? `<img src="${escapeHtml(bot.profile_photo)}" alt="" width="96" height="96" class="rounded-full ring-2 ring-base-300">`
+      : `<div class="w-24 h-24 rounded-full bg-base-300 flex items-center justify-center text-4xl ring-2 ring-base-300">🤖</div>`;
 
     const entriesHtml = entries.length > 0
       ? entries.map((entry) => {
           const date = entry.publishedAt
-            ? `<time datetime="${entry.publishedAt.toISOString()}">${entry.publishedAt.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}</time>`
+            ? `<time datetime="${entry.publishedAt.toISOString()}" class="text-xs text-base-content/50 whitespace-nowrap">${entry.publishedAt.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}</time>`
             : "";
           const link = entry.url
-            ? `<a href="${escapeHtml(entry.url)}">${escapeHtml(entry.title)}</a>`
-            : escapeHtml(entry.title);
-          return `<li>${link}${date ? ` <small>${date}</small>` : ""}</li>`;
+            ? `<a href="${escapeHtml(entry.url)}" class="link link-hover font-medium">${escapeHtml(entry.title)}</a>`
+            : `<span class="font-medium">${escapeHtml(entry.title)}</span>`;
+          return `<li class="flex items-baseline justify-between gap-4 py-2">${link}${date}</li>`;
         }).join("\n")
-      : "<li><em>No posts yet.</em></li>";
+      : `<li class="py-4 text-base-content/50 italic">No posts yet.</li>`;
 
     const paginationHtml = (hasPrev || hasNext)
-      ? `<nav style="margin-top:1em">${hasPrev ? `<a href="/@${escapeHtml(username)}?page=${page - 1}">&laquo; Newer</a>` : ""}${hasPrev && hasNext ? " | " : ""}${hasNext ? `<a href="/@${escapeHtml(username)}?page=${page + 1}">Older &raquo;</a>` : ""}</nav>`
+      ? `<div class="join mt-6">${hasPrev ? `<a href="/@${escapeHtml(username)}?page=${page - 1}" class="join-item btn btn-sm">&laquo; Newer</a>` : ""}${hasNext ? `<a href="/@${escapeHtml(username)}?page=${page + 1}" class="join-item btn btn-sm">Older &raquo;</a>` : ""}</div>`
       : "";
 
-    const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${escapeHtml(bot.display_name)} (@${escapeHtml(username)}@${escapeHtml(domain)}) – ${escapeHtml(domain)}</title>
-  <script type="module" src="https://unpkg.com/mastodon-widget"></script>
-</head>
-<body>
-  <header>
-    ${photoHtml}
-    <h1>${escapeHtml(bot.display_name)}</h1>
-    <p><code>@${escapeHtml(username)}@${escapeHtml(domain)}</code></p>
-    <p>${escapeHtml(bot.summary)}</p>
-    <p style="font-size:0.9em;color:#666">This is a bot that mirrors an RSS feed. Source: <a href="${escapeHtml(bot.feed_url)}">${escapeHtml(bot.feed_url)}</a></p>
-    <mastodon-follow account="${escapeHtml(username)}@${escapeHtml(domain)}" style="margin-top:0.75em;display:inline-block">
-      <button style="cursor:pointer">Follow on Mastodon</button>
-    </mastodon-follow>
-  </header>
-  <dl style="display:flex;gap:2em;margin:1em 0">
-    <div><dt style="font-size:0.85em;color:#666">Posts</dt><dd style="margin:0;font-size:1.25em;font-weight:bold">${total.toLocaleString("en-US")}</dd></div>
-    <div><dt style="font-size:0.85em;color:#666">Followers</dt><dd style="margin:0;font-size:1.25em;font-weight:bold">${followerCount.toLocaleString("en-US")}</dd></div>
-  </dl>
-  <h2>Posts</h2>
-  <ul>
-${entriesHtml}
-  </ul>
-  ${paginationHtml}
-  <p style="margin-top:2em"><a href="/">&larr; All bots</a></p>
-  <footer style="margin-top:2em;padding-top:1em;border-top:1px solid #ddd;font-size:0.85em;color:#666">
-    <p>&copy; <a href="https://natwelch.com">Nat Welch</a> · <a href="https://github.com/icco/robot.villas">Source code</a> · <a href="https://github.com/icco/robot.villas/edit/main/feeds.yml">Add or update a feed</a></p>
-  </footer>
-</body>
-</html>`;
-    return c.html(html);
+    const content = `
+      <a href="/" class="btn btn-ghost btn-sm gap-1 mb-6 -ml-2">
+        <span>&larr;</span> All bots
+      </a>
+      <div class="flex items-start gap-6 mb-6">
+        ${photoHtml}
+        <div>
+          <h1 class="text-3xl font-display font-bold tracking-tight">${escapeHtml(bot.display_name)}</h1>
+          <p class="font-mono text-sm text-base-content/60 mt-1">@${escapeHtml(username)}@${escapeHtml(domain)}</p>
+          <p class="mt-2 text-base-content/80">${escapeHtml(bot.summary)}</p>
+          <p class="text-sm text-base-content/50 mt-2">Source: <a href="${escapeHtml(bot.feed_url)}" class="link link-hover">${escapeHtml(bot.feed_url)}</a></p>
+          <mastodon-follow account="${escapeHtml(username)}@${escapeHtml(domain)}" class="mt-3 inline-block">
+            <button class="btn btn-primary btn-sm">Follow on Mastodon</button>
+          </mastodon-follow>
+        </div>
+      </div>
+      <div class="stats shadow bg-base-200 mb-8">
+        <div class="stat">
+          <div class="stat-title">Posts</div>
+          <div class="stat-value text-2xl">${total.toLocaleString("en-US")}</div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">Followers</div>
+          <div class="stat-value text-2xl">${followerCount.toLocaleString("en-US")}</div>
+        </div>
+      </div>
+      <h2 class="text-xl font-display font-bold mb-3">Posts</h2>
+      <ul class="divide-y divide-base-300">
+        ${entriesHtml}
+      </ul>
+      ${paginationHtml}`;
+
+    return c.html(layout({
+      title: `${bot.display_name} (@${username}@${domain}) – ${domain}`,
+      domain,
+      content,
+      extraHead: `<script type="module" src="https://unpkg.com/mastodon-widget"></script>`,
+    }));
   });
 
   return app;


### PR DESCRIPTION
Migrate from inline styles to Tailwind CSS v4 and daisyUI v5 (via CDN). Extract a shared layout with consistent header (links to home) and footer across all pages. Use Space Mono + DM Sans for typography, daisyUI "dim" theme, and component classes throughout.