### PR TITLE
Feed poll status on /status and ActivityPub following + UI lists

### DIFF
--- a/drizzle/0009_natural_gideon.sql
+++ b/drizzle/0009_natural_gideon.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "feed_poll_status" (
+	"bot_username" text PRIMARY KEY NOT NULL,
+	"last_checked_at" timestamp with time zone NOT NULL,
+	"last_http_status" integer,
+	"last_error" text
+);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,462 @@
+{
+  "id": "e9579188-44d6-4deb-b69e-6878fee06603",
+  "prevId": "da1efbc3-8429-42d7-8f6f-8422ee38035b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor_keypairs": {
+      "name": "actor_keypairs",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_entries": {
+      "name": "feed_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feed_entries_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boost_count": {
+          "name": "boost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_entries_bot_username_guid_unique": {
+          "name": "feed_entries_bot_username_guid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "guid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_poll_status": {
+      "name": "feed_poll_status",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followers": {
+      "name": "followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_id": {
+          "name": "follow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followers_bot_username_follower_id_unique": {
+          "name": "followers_bot_username_follower_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "follower_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.following": {
+      "name": "following",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "following_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_actor_id": {
+          "name": "target_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "following_bot_username_handle_unique": {
+          "name": "following_bot_username_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relays": {
+      "name": "relays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "relays_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "relay_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "relays_bot_username_url_unique": {
+          "name": "relays_bot_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.relay_status": {
+      "name": "relay_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776026396203,
       "tag": "0008_relay_per_bot",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776030978129,
+      "tag": "0009_natural_gideon",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -60,6 +60,14 @@ const nextConfig: NextConfig = {
         source: "/@:username",
         destination: "/bot/:username",
       },
+      {
+        source: "/@:username/followers",
+        destination: "/bot/:username/followers",
+      },
+      {
+        source: "/@:username/following",
+        destination: "/bot/:username/following",
+      },
     ];
   },
   async headers() {

--- a/src/app/bot/[username]/followers/page.tsx
+++ b/src/app/bot/[username]/followers/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getGlobals } from "@/lib/globals";
+import { getFollowers } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  params: Promise<{ username: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { username } = await params;
+  const { config, domain } = getGlobals();
+  const bot = config.bots[username];
+  if (!bot) {
+    return {};
+  }
+  return {
+    title: `Followers — ${bot.display_name} (@${username})`,
+    description: `Accounts following @${username}@${domain} via ActivityPub.`,
+    alternates: {
+      canonical: `https://${domain}/@${username}/followers`,
+    },
+  };
+}
+
+export default async function BotFollowersPage({ params }: Props) {
+  const { username } = await params;
+  const { config, domain, db } = getGlobals();
+  const bot = config.bots[username];
+  if (!bot) {
+    notFound();
+  }
+  const followers = (await getFollowers(db, username)).slice().sort();
+
+  return (
+    <>
+      <Link href={`/@${username}`} className="btn btn-ghost btn-sm gap-1 mb-6 -ml-2">
+        <span>&larr;</span> @{username}
+      </Link>
+      <h1 className="text-2xl font-display font-bold tracking-tight mb-2">Followers</h1>
+      <p className="text-base-content/60 text-sm mb-6">
+        <span className="font-mono">@{username}@{domain}</span>
+        {" · "}
+        <a
+          href={`https://${domain}/users/${username}/followers`}
+          className="link link-hover"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ActivityPub collection
+        </a>
+      </p>
+      <ul className="space-y-2">
+        {followers.length === 0 ? (
+          <li className="text-base-content/50 text-sm">No followers yet.</li>
+        ) : (
+          followers.map((id) => (
+            <li key={id}>
+              <a
+                href={id}
+                className="link link-hover font-mono text-xs break-all"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {id}
+              </a>
+            </li>
+          ))
+        )}
+      </ul>
+    </>
+  );
+}

--- a/src/app/bot/[username]/following/page.tsx
+++ b/src/app/bot/[username]/following/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getGlobals } from "@/lib/globals";
+import { getFollowingListForBot } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  params: Promise<{ username: string }>;
+}
+
+function FollowStateLabel({ status }: { status: string }) {
+  if (status === "accepted") {
+    return <span className="text-success text-xs font-medium">accepted</span>;
+  }
+  if (status === "rejected") {
+    return <span className="text-error text-xs font-medium">rejected</span>;
+  }
+  return <span className="text-warning text-xs font-medium">pending</span>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { username } = await params;
+  const { config, domain } = getGlobals();
+  const bot = config.bots[username];
+  if (!bot) {
+    return {};
+  }
+  return {
+    title: `Following — ${bot.display_name} (@${username})`,
+    description: `Accounts @${username}@${domain} follows via ActivityPub.`,
+    alternates: {
+      canonical: `https://${domain}/@${username}/following`,
+    },
+  };
+}
+
+export default async function BotFollowingPage({ params }: Props) {
+  const { username } = await params;
+  const { config, domain, db } = getGlobals();
+  const bot = config.bots[username];
+  if (!bot) {
+    notFound();
+  }
+  const following = await getFollowingListForBot(db, username);
+
+  return (
+    <>
+      <Link href={`/@${username}`} className="btn btn-ghost btn-sm gap-1 mb-6 -ml-2">
+        <span>&larr;</span> @{username}
+      </Link>
+      <h1 className="text-2xl font-display font-bold tracking-tight mb-2">Following</h1>
+      <p className="text-base-content/60 text-sm mb-6">
+        <span className="font-mono">@{username}@{domain}</span>
+        {" · "}
+        <a
+          href={`https://${domain}/users/${username}/following`}
+          className="link link-hover"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ActivityPub collection
+        </a>
+      </p>
+      {following.length === 0 ? (
+        <p className="text-base-content/50 text-sm">This bot is not following any accounts yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="table table-sm w-full">
+            <thead>
+              <tr>
+                <th>Handle</th>
+                <th>Status</th>
+                <th className="hidden sm:table-cell">Actor</th>
+              </tr>
+            </thead>
+            <tbody>
+              {following.map((row) => (
+                <tr key={row.handle}>
+                  <td className="font-mono text-xs">@{row.handle}</td>
+                  <td>
+                    <FollowStateLabel status={row.status} />
+                  </td>
+                  <td className="hidden sm:table-cell">
+                    {row.targetActorId ? (
+                      <a
+                        href={row.targetActorId}
+                        className="link link-hover font-mono text-xs break-all"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {row.targetActorId}
+                      </a>
+                    ) : (
+                      <span className="text-base-content/40 text-xs">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/bot/[username]/page.tsx
+++ b/src/app/bot/[username]/page.tsx
@@ -4,7 +4,12 @@ import { notFound } from "next/navigation";
 import { ArrowPathRoundedSquareIcon, HeartIcon } from "@heroicons/react/24/outline";
 import { CpuChipIcon } from "@heroicons/react/24/solid";
 import { getGlobals } from "@/lib/globals";
-import { countEntries, countFollowers, getEntriesPage } from "@/lib/db";
+import {
+  countAcceptedFollowing,
+  countEntries,
+  countFollowers,
+  getEntriesPage,
+} from "@/lib/db";
 import { FollowButton, InteractButton } from "./mastodon-widgets";
 
 const PROFILE_PAGE_SIZE = 40;
@@ -46,9 +51,10 @@ export default async function BotProfilePage({ params, searchParams }: Props) {
   const { page: pageParam } = await searchParams;
   const page = parseInt(pageParam || "0", 10);
   const offset = Math.max(0, page) * PROFILE_PAGE_SIZE;
-  const [total, followerCount, entries] = await Promise.all([
+  const [total, followerCount, followingCount, entries] = await Promise.all([
     countEntries(db, username),
     countFollowers(db, username),
+    countAcceptedFollowing(db, username),
     getEntriesPage(db, username, PROFILE_PAGE_SIZE, offset),
   ]);
   const hasNext = offset + entries.length < total;
@@ -102,12 +108,18 @@ export default async function BotProfilePage({ params, searchParams }: Props) {
                   {total.toLocaleString("en-US")}
                 </div>
               </div>
-              <div className="stat px-4 py-2">
+              <Link href={`/@${username}/followers`} className="stat px-4 py-2 hover:bg-base-300/60 transition-colors">
                 <div className="stat-title text-xs">Followers</div>
                 <div className="stat-value text-lg">
                   {followerCount.toLocaleString("en-US")}
                 </div>
-              </div>
+              </Link>
+              <Link href={`/@${username}/following`} className="stat px-4 py-2 hover:bg-base-300/60 transition-colors">
+                <div className="stat-title text-xs">Following</div>
+                <div className="stat-value text-lg">
+                  {followingCount.toLocaleString("en-US")}
+                </div>
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -7,7 +7,7 @@ import {
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
 import { getGlobals } from "@/lib/globals";
-import { getRelayStatusSummary, getFollowingStatusSummary } from "@/lib/db";
+import { getFeedPollStatusMap, getRelayStatusSummary, getFollowingStatusSummary } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
@@ -67,9 +67,11 @@ function StatusCell({ count, type }: { count: number; type: "accepted" | "pendin
 export default async function StatusPage() {
   const { config, db } = getGlobals();
   const botCount = Object.keys(config.bots).length;
-  const [relaySummary, followingSummary] = await Promise.all([
+  const botUsernames = Object.keys(config.bots).sort((a, b) => a.localeCompare(b));
+  const [relaySummary, followingSummary, feedPollMap] = await Promise.all([
     getRelayStatusSummary(db),
     getFollowingStatusSummary(db),
+    getFeedPollStatusMap(db, botUsernames),
   ]);
 
   const configuredRelays = config.relays ?? [];
@@ -179,12 +181,16 @@ export default async function StatusPage() {
                 <th>Bot</th>
                 <th className="hidden sm:table-cell">Name</th>
                 <th>Feed URL</th>
+                <th className="whitespace-nowrap">Last HTTP check</th>
+                <th className="text-right whitespace-nowrap">HTTP</th>
+                <th className="hidden md:table-cell">Last error</th>
               </tr>
             </thead>
             <tbody>
-              {Object.entries(config.bots)
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([username, bot]) => (
+              {botUsernames.map((username) => {
+                const bot = config.bots[username];
+                const poll = feedPollMap.get(username);
+                return (
                   <tr key={username}>
                     <td>
                       <Link
@@ -205,8 +211,29 @@ export default async function StatusPage() {
                         {bot.feed_url}
                       </a>
                     </td>
+                    <td className="text-xs text-base-content/80 whitespace-nowrap">
+                      {poll
+                        ? poll.lastCheckedAt.toLocaleString("en-US", {
+                          dateStyle: "medium",
+                          timeStyle: "short",
+                        })
+                        : "—"}
+                    </td>
+                    <td className="text-right font-mono text-xs">
+                      {!poll ? (
+                        <span className="text-base-content/40">—</span>
+                      ) : poll.lastHttpStatus != null ? (
+                        <span className={poll.lastError ? "text-error" : "text-success"}>{poll.lastHttpStatus}</span>
+                      ) : (
+                        <span className="text-base-content/40">—</span>
+                      )}
+                    </td>
+                    <td className="hidden md:table-cell text-xs text-error break-all max-w-xs">
+                      {poll?.lastError ?? ""}
+                    </td>
                   </tr>
-                ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -25,6 +25,7 @@ async function cleanTestData(db: Db) {
   await db.delete(schema.feedEntries).where(inArray(schema.feedEntries.botUsername, TEST_BOTS));
   await db.delete(schema.actorKeypairs).where(inArray(schema.actorKeypairs.botUsername, TEST_BOTS));
   await db.delete(schema.followers).where(inArray(schema.followers.botUsername, TEST_BOTS));
+  await db.delete(schema.feedPollStatus).where(inArray(schema.feedPollStatus.botUsername, TEST_BOTS));
 }
 
 describeWithDb("database", () => {

--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { extractFeedCategories, MAX_ITEMS_PER_POLL, parseFeedXml, type FeedEntry } from "../rss";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  extractFeedCategories,
+  fetchFeedWithHttpResult,
+  MAX_ITEMS_PER_POLL,
+  parseFeedXml,
+  type FeedEntry,
+} from "../rss";
 import type { Item } from "rss-parser";
 
 const SAMPLE_RSS = `<?xml version="1.0" encoding="UTF-8"?>
@@ -108,5 +114,30 @@ describe("parseFeedXml", () => {
     expect(entries).toHaveLength(MAX_ITEMS_PER_POLL);
     expect(entries[0]?.title).toBe("Item 0");
     expect(entries[MAX_ITEMS_PER_POLL - 1]?.title).toBe(`Item ${MAX_ITEMS_PER_POLL - 1}`);
+  });
+});
+
+describe("fetchFeedWithHttpResult", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns HTTP status and no entries on non-OK responses", async () => {
+    globalThis.fetch = async () => new Response("", { status: 503 });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.httpStatus).toBe(503);
+    expect(r.errorMessage).toMatch(/503/);
+    expect(r.entries).toEqual([]);
+  });
+
+  it("parses entries on successful responses", async () => {
+    globalThis.fetch = async () =>
+      new Response(SAMPLE_RSS, { status: 200, headers: { "Content-Type": "application/rss+xml" } });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.httpStatus).toBe(200);
+    expect(r.errorMessage).toBeNull();
+    expect(r.entries.length).toBe(2);
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate as runMigrations } from "drizzle-orm/postgres-js/migrator";
 import type postgres from "postgres";
@@ -586,4 +586,97 @@ export async function getFollowingByActivityId(
     .where(and(eq(schema.following.followActivityId, followActivityId), isNull(schema.following.deletedAt)))
     .limit(1);
   return rows[0] ?? null;
+}
+
+export async function countAcceptedFollowing(db: Db, botUsername: string): Promise<number> {
+  const rows = await db
+    .select({ value: count() })
+    .from(schema.following)
+    .where(
+      and(
+        eq(schema.following.botUsername, botUsername),
+        eq(schema.following.status, "accepted"),
+        isNull(schema.following.deletedAt),
+        isNotNull(schema.following.targetActorId),
+      ),
+    );
+  return rows[0]?.value ?? 0;
+}
+
+export async function getAcceptedFollowingActorIds(db: Db, botUsername: string): Promise<string[]> {
+  const rows = await db
+    .select({ targetActorId: schema.following.targetActorId })
+    .from(schema.following)
+    .where(
+      and(
+        eq(schema.following.botUsername, botUsername),
+        eq(schema.following.status, "accepted"),
+        isNull(schema.following.deletedAt),
+        isNotNull(schema.following.targetActorId),
+      ),
+    )
+    .orderBy(asc(schema.following.handle));
+  return rows.map((r) => r.targetActorId!);
+}
+
+export interface FollowingListItem {
+  handle: string;
+  targetActorId: string | null;
+  status: string;
+}
+
+export async function getFollowingListForBot(db: Db, botUsername: string): Promise<FollowingListItem[]> {
+  return db
+    .select({
+      handle: schema.following.handle,
+      targetActorId: schema.following.targetActorId,
+      status: schema.following.status,
+    })
+    .from(schema.following)
+    .where(and(eq(schema.following.botUsername, botUsername), isNull(schema.following.deletedAt)))
+    .orderBy(asc(schema.following.handle));
+}
+
+// --- RSS feed poll status ---
+
+export interface FeedPollStatusRow {
+  botUsername: string;
+  lastCheckedAt: Date;
+  lastHttpStatus: number | null;
+  lastError: string | null;
+}
+
+export async function upsertFeedPollStatus(
+  db: Db,
+  botUsername: string,
+  lastCheckedAt: Date,
+  lastHttpStatus: number | null,
+  lastError: string | null,
+): Promise<void> {
+  await db
+    .insert(schema.feedPollStatus)
+    .values({ botUsername, lastCheckedAt, lastHttpStatus, lastError })
+    .onConflictDoUpdate({
+      target: schema.feedPollStatus.botUsername,
+      set: { lastCheckedAt, lastHttpStatus, lastError },
+    });
+}
+
+export async function getFeedPollStatusMap(
+  db: Db,
+  botUsernames: string[],
+): Promise<Map<string, FeedPollStatusRow>> {
+  if (botUsernames.length === 0) {
+    return new Map();
+  }
+  const rows = await db
+    .select({
+      botUsername: schema.feedPollStatus.botUsername,
+      lastCheckedAt: schema.feedPollStatus.lastCheckedAt,
+      lastHttpStatus: schema.feedPollStatus.lastHttpStatus,
+      lastError: schema.feedPollStatus.lastError,
+    })
+    .from(schema.feedPollStatus)
+    .where(inArray(schema.feedPollStatus.botUsername, botUsernames));
+  return new Map(rows.map((r) => [r.botUsername, r]));
 }

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -34,6 +34,7 @@ import type { BotConfig, FeedsConfig } from "./config";
 import {
   addFollower,
   countEntries,
+  countAcceptedFollowing,
   countFollowers,
   decrementBoostCount,
   decrementLikeCount,
@@ -43,6 +44,7 @@ import {
   getEntriesPage,
   getEntryById,
   getFollowerRecipients,
+  getAcceptedFollowingActorIds,
   getFollowers,
   getFollowingByActivityId,
   getKeypairs,
@@ -114,6 +116,7 @@ async function buildActor(
     inbox: ctx.getInboxUri(identifier),
     outbox: ctx.getOutboxUri(identifier),
     followers: ctx.getFollowersUri(identifier),
+    following: ctx.getFollowingUri(identifier),
     endpoints: new Endpoints({
       sharedInbox: ctx.getInboxUri(),
     }),
@@ -466,6 +469,22 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
       return null;
     }
     return await countFollowers(db, identifier);
+  });
+
+  federation.setFollowingDispatcher(
+    "/users/{identifier}/following",
+    async (_ctx, identifier) => {
+      if (!botUsernames.includes(identifier)) {
+        return null;
+      }
+      const actorIds = await getAcceptedFollowingActorIds(db, identifier);
+      return { items: actorIds.map((id) => new URL(id)) };
+    },
+  ).setCounter(async (_ctx, identifier) => {
+    if (!botUsernames.includes(identifier)) {
+      return null;
+    }
+    return await countAcceptedFollowing(db, identifier);
   });
 
   // --- NodeInfo dispatcher ---

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -1,8 +1,8 @@
 import type { Context } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
 import type { FeedsConfig } from "./config";
-import type { Db } from "./db";
-import { fetchFeed } from "./rss";
+import { upsertFeedPollStatus, type Db } from "./db";
+import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
@@ -32,12 +32,32 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
     logger.info("Poll cycle starting");
     const ctx = getContext();
     for (const [username, bot] of Object.entries(config.bots)) {
+      const checkedAt = new Date();
       try {
-        const entries = await fetchFeed(bot.feed_url);
-        const result = await publishNewEntries(ctx, db, username, domain, entries, bot);
+        const fetchResult = await fetchFeedWithHttpResult(bot.feed_url);
+        await upsertFeedPollStatus(
+          db,
+          username,
+          checkedAt,
+          fetchResult.httpStatus,
+          fetchResult.errorMessage,
+        );
+        if (fetchResult.errorMessage) {
+          logger.warn("Feed poll failed for {username}: {message}", {
+            username,
+            message: fetchResult.errorMessage,
+          });
+          continue;
+        }
+        const result = await publishNewEntries(ctx, db, username, domain, fetchResult.entries, bot);
         logger.info(
           "Fetched {entryCount} entries for {username}, published {published}, skipped {skipped}",
-          { username, entryCount: entries.length, published: result.published, skipped: result.skipped },
+          {
+            username,
+            entryCount: fetchResult.entries.length,
+            published: result.published,
+            skipped: result.skipped,
+          },
         );
       } catch (err) {
         logger.error("Error polling {username}: {error}", { username, error: err });

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -2,6 +2,8 @@ import Parser from "rss-parser";
 
 const parser = new Parser({ timeout: 10_000 });
 
+const FEED_FETCH_TIMEOUT_MS = 10_000;
+
 /** Max items to process per feed per poll; limits DoS from huge feeds. */
 export const MAX_ITEMS_PER_POLL = 100;
 
@@ -14,10 +16,57 @@ export interface FeedEntry {
   feedCategories: string[];
 }
 
+export interface FeedFetchResult {
+  entries: FeedEntry[];
+  /** HTTP status when a response was received; null on errors before a response (e.g. timeout). */
+  httpStatus: number | null;
+  /** Null when the feed was fetched with a 2xx/3xx response and parsed successfully. */
+  errorMessage: string | null;
+}
+
+/**
+ * Fetches a feed over HTTP, records status for observability, and parses the body when the response is OK.
+ */
+export async function fetchFeedWithHttpResult(feedUrl: string): Promise<FeedFetchResult> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FEED_FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(feedUrl, {
+        signal: controller.signal,
+        redirect: "follow",
+        headers: {
+          Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
+          "User-Agent": "robot.villas RSS poller",
+        },
+      });
+      const httpStatus = res.status;
+      if (!res.ok) {
+        return { entries: [], httpStatus, errorMessage: `HTTP ${httpStatus}` };
+      }
+      const text = await res.text();
+      try {
+        const entries = await parseFeedXml(text);
+        return { entries, httpStatus, errorMessage: null };
+      } catch (parseErr) {
+        const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+        return { entries: [], httpStatus, errorMessage: msg };
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { entries: [], httpStatus: null, errorMessage: msg };
+  }
+}
+
 export async function fetchFeed(feedUrl: string): Promise<FeedEntry[]> {
-  const feed = await parser.parseURL(feedUrl);
-  const items = feed.items.map(normalizeFeedItem);
-  return items.slice(0, MAX_ITEMS_PER_POLL);
+  const { entries, errorMessage } = await fetchFeedWithHttpResult(feedUrl);
+  if (errorMessage) {
+    throw new Error(errorMessage);
+  }
+  return entries;
 }
 
 export async function parseFeedXml(xml: string): Promise<FeedEntry[]> {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -78,3 +78,13 @@ export const relays = pgTable(
   },
   (t) => [unique().on(t.botUsername, t.url)],
 );
+
+/** Last HTTP poll outcome per bot RSS feed (keyed by bot username). */
+export const feedPollStatus = pgTable("feed_poll_status", {
+  botUsername: text("bot_username").primaryKey(),
+  lastCheckedAt: timestamp("last_checked_at", { withTimezone: true, mode: "date" }).notNull(),
+  /** Response status when a response was received; null on network/timeout errors before headers. */
+  lastHttpStatus: integer("last_http_status"),
+  /** Null when the last poll completed successfully at HTTP + parse level. */
+  lastError: text("last_error"),
+});


### PR DESCRIPTION
## Summary

This PR adds observability for RSS polling and makes following/followers discoverable for both humans and ActivityPub clients.

### Feed HTTP checks (`/status`)
- New `feed_poll_status` table (migration `0009_natural_gideon`) stores the last poll time, HTTP status, and error text per bot.
- The poller uses `fetch()` via `fetchFeedWithHttpResult` so status codes are recorded on every cycle; entries are only parsed and published when the response is OK.
- The RSS section on `/status` shows last check time, HTTP code, and last error.

### Following and followers (federation + UI)
- Actors now advertise a `following` collection (`Context.getFollowingUri`).
- `/users/{identifier}/following` is served for ActivityPub requests, listing **accepted** follows as actor URLs, with a collection counter.
- New human-readable pages: `/@{username}/followers` and `/@{username}/following` (with Next rewrites). Bot profile stats link to these pages; **Following** count matches the ActivityPub collection (accepted only).

### Tests
- Vitest coverage for `fetchFeedWithHttpResult` with a stubbed `fetch`.

## Deploy notes
- Run DB migrations before or on deploy so `feed_poll_status` exists.
- Until the first successful poll per bot, `/status` may show "—" for that feed's poll columns.

Made with [Cursor](https://cursor.com)