### PR TITLE
feat: use feed categories as Gemini context only

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import nextPlugin from "@next/eslint-plugin-next";
+import stylistic from "@stylistic/eslint-plugin";
 
 export default defineConfig([
   js.configs.recommended,
@@ -9,6 +10,7 @@ export default defineConfig([
   {
     plugins: {
       "@next/next": nextPlugin,
+      "@stylistic": stylistic,
     },
     rules: {
       ...nextPlugin.configs.recommended.rules,
@@ -21,6 +23,7 @@ export default defineConfig([
   {
     rules: {
       curly: "error",
+      "@stylistic/brace-style": ["error", "1tbs", { allowSingleLine: false }],
     },
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@next/eslint-plugin-next": "^15.5.12",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@tailwindcss/postcss": "^4",
     "@types/escape-html": "^1.0.4",
     "@types/js-yaml": "^4.0.9",

--- a/src/app/bot/[username]/page.tsx
+++ b/src/app/bot/[username]/page.tsx
@@ -133,7 +133,7 @@ export default async function BotProfilePage({ params, searchParams }: Props) {
               key={entry.id}
               className="flex items-baseline justify-between gap-4 py-2"
             >
-              <span className="flex items-baseline gap-3 min-w-0">
+              <span className="flex flex-wrap items-baseline gap-x-3 gap-y-1 min-w-0">
                 {entry.url ? (
                   <a
                     href={entry.url}
@@ -143,6 +143,15 @@ export default async function BotProfilePage({ params, searchParams }: Props) {
                   </a>
                 ) : (
                   <span className="font-medium">{entry.title}</span>
+                )}
+                {entry.hashtags && entry.hashtags.length > 0 && (
+                  <span className="flex gap-1 flex-wrap">
+                    {entry.hashtags.map((tag) => (
+                      <span key={tag} className="text-xs text-primary/70 font-mono">
+                        #{tag}
+                      </span>
+                    ))}
+                  </span>
                 )}
               </span>
               <span className="flex items-center gap-1 shrink-0">

--- a/src/lib/__tests__/hashtags.test.ts
+++ b/src/lib/__tests__/hashtags.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import {
   hashtagsForNoteBody,
   mergeHashtagCandidates,
@@ -51,11 +51,17 @@ describe("normalizeHashtagLabel", () => {
 });
 
 describe("resolveHashtags", () => {
+  beforeEach(() => {
+    // Ensure no Gemini env vars bleed in from the environment unless a test sets them.
+    vi.stubEnv("GEMINI_API_KEY", "");
+    vi.stubEnv("GEMINI_PROJECT", "");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("takes first three distinct feed categories", async () => {
+  it("falls back to feed categories when Gemini is not configured", async () => {
     const tags = await resolveHashtags(
       makeEntry({
         title: "T",
@@ -68,7 +74,7 @@ describe("resolveHashtags", () => {
     expect(tags).toEqual(["rust", "lang", "systems"]);
   });
 
-  it("uses only default_hashtags when feed has no categories", async () => {
+  it("falls back to default_hashtags when feed has no categories and Gemini is not configured", async () => {
     const tags = await resolveHashtags(makeEntry({ title: "Hello world today" }), "nyt_world", {
       ...baseBot,
       default_hashtags: ["World", "News"],
@@ -77,7 +83,6 @@ describe("resolveHashtags", () => {
   });
 
   it("returns empty when no categories, defaults, or Gemini", async () => {
-    vi.stubEnv("GEMINI_API_KEY", "");
     const tags = await resolveHashtags(
       makeEntry({ title: "The quick brown fox", link: "https://example.com/x", feedCategories: [] }),
       "danluu",
@@ -85,5 +90,23 @@ describe("resolveHashtags", () => {
       { geminiApiKey: "" },
     );
     expect(tags).toEqual([]);
+  });
+
+  it("seeds pool from default_hashtags only (not categories) when Gemini is configured", async () => {
+    // Gemini is "configured" but we expect it to fail; the pool should only contain defaults,
+    // proving categories were not added directly.
+    const tags = await resolveHashtags(
+      makeEntry({
+        title: "T",
+        feedCategories: ["ShouldNotAppear", "AlsoNot"],
+      }),
+      "my_bot",
+      { ...baseBot, default_hashtags: ["DefaultTag"] },
+      { geminiApiKey: "fake-key-that-will-fail" },
+    );
+    // Gemini call will throw; we fall back to whatever is in the pool (defaults only).
+    expect(tags).not.toContain("ShouldNotAppear");
+    expect(tags).not.toContain("AlsoNot");
+    expect(tags).toContain("DefaultTag");
   });
 });

--- a/src/lib/__tests__/hashtags.test.ts
+++ b/src/lib/__tests__/hashtags.test.ts
@@ -1,4 +1,13 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: class {
+    models = {
+      generateContent: vi.fn().mockRejectedValue(new Error("mock: no real API calls in tests")),
+    };
+  },
+}));
+
 import {
   hashtagsForNoteBody,
   mergeHashtagCandidates,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -411,8 +411,12 @@ export async function getAcceptedRelays(db: Db): Promise<RelayRow[]> {
   // Deduplicate by inboxUrl so we don't deliver to the same relay inbox more than once.
   const seen = new Set<string>();
   return rows.filter((r) => {
-    if (!r.inboxUrl) { return false; }
-    if (seen.has(r.inboxUrl)) { return false; }
+    if (!r.inboxUrl) {
+      return false;
+    }
+    if (seen.has(r.inboxUrl)) {
+      return false;
+    }
     seen.add(r.inboxUrl);
     return true;
   });
@@ -489,9 +493,13 @@ export async function getRelayStatusSummary(db: Db): Promise<RelayStatusSummary[
   const map = new Map<string, RelayStatusSummary>();
   for (const row of rows) {
     const existing = map.get(row.url) ?? { url: row.url, pending: 0, accepted: 0, rejected: 0 };
-    if (row.status === "accepted") { existing.accepted++; }
-    else if (row.status === "rejected") { existing.rejected++; }
-    else { existing.pending++; }
+    if (row.status === "accepted") {
+      existing.accepted++;
+    } else if (row.status === "rejected") {
+      existing.rejected++;
+    } else {
+      existing.pending++;
+    }
     map.set(row.url, existing);
   }
   return [...map.values()];
@@ -512,9 +520,13 @@ export async function getFollowingStatusSummary(db: Db): Promise<FollowingStatus
   const map = new Map<string, FollowingStatusSummary>();
   for (const row of rows) {
     const existing = map.get(row.handle) ?? { handle: row.handle, pending: 0, accepted: 0, rejected: 0 };
-    if (row.status === "accepted") { existing.accepted++; }
-    else if (row.status === "rejected") { existing.rejected++; }
-    else { existing.pending++; }
+    if (row.status === "accepted") {
+      existing.accepted++;
+    } else if (row.status === "rejected") {
+      existing.rejected++;
+    } else {
+      existing.pending++;
+    }
     map.set(row.handle, existing);
   }
   return [...map.values()];

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -164,7 +164,9 @@ export interface ResolveHashtagsOptions {
 }
 
 /**
- * Up to MAX_TAGS labels: feed categories + config defaults, then optional Gemini. No title/URL heuristics.
+ * Up to MAX_TAGS labels. When Gemini is available, feed categories are used only as
+ * context in the Gemini prompt (not added directly to the pool); default_hashtags always
+ * seed the pool. Without Gemini, falls back to categories + defaults as direct hashtags.
  */
 export async function resolveHashtags(
   entry: FeedEntry,
@@ -172,15 +174,24 @@ export async function resolveHashtags(
   bot: BotConfig,
   opts: ResolveHashtagsOptions = {},
 ): Promise<string[]> {
-  const raw = [...entry.feedCategories, ...(bot.default_hashtags ?? [])];
-  const pool = mergeHashtagCandidates(raw, MAX_TAGS);
-  const need = MAX_TAGS - pool.length;
   const apiKey = opts.geminiApiKey ?? process.env.GEMINI_API_KEY;
   const model = opts.geminiModel ?? process.env.GEMINI_MODEL ?? GEMINI_DEFAULT_MODEL;
   const project = opts.geminiProject ?? process.env.GEMINI_PROJECT;
   const location = opts.geminiLocation ?? process.env.GEMINI_LOCATION;
+  const hasGemini = !!(apiKey || project);
 
-  if (need <= 0 || (!apiKey && !project)) {
+  if (!hasGemini) {
+    // No Gemini: use feed categories + config defaults directly as hashtags.
+    return mergeHashtagCandidates(
+      [...entry.feedCategories, ...(bot.default_hashtags ?? [])],
+      MAX_TAGS,
+    );
+  }
+
+  // Gemini available: seed pool from default_hashtags only; categories go into the prompt.
+  const pool = mergeHashtagCandidates(bot.default_hashtags ?? [], MAX_TAGS);
+  const need = MAX_TAGS - pool.length;
+  if (need <= 0) {
     return pool;
   }
 

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -80,11 +80,20 @@ function parseGeminiTagsJson(text: string): string[] {
     }
     return data.tags.filter((x): x is string => typeof x === "string");
   };
+  // Try raw text first.
   try {
     return tryParse(trim);
-  } catch {
+  } catch { /* fall through */ }
+  // Strip markdown code fences.
+  try {
     return tryParse(trim.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/u, ""));
+  } catch { /* fall through */ }
+  // Extract the first {...} block in case the model prepended prose.
+  const match = /\{[\s\S]*\}/u.exec(trim);
+  if (match) {
+    return tryParse(match[0]);
   }
+  throw new Error("no JSON object found in Gemini response");
 }
 
 async function geminiSuggestMissingTags(params: {

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -83,11 +83,15 @@ function parseGeminiTagsJson(text: string): string[] {
   // Try raw text first.
   try {
     return tryParse(trim);
-  } catch { /* fall through */ }
+  } catch (e) {
+    logger.debug("Gemini JSON parse (raw) failed, trying next strategy: {error}", { error: e });
+  }
   // Strip markdown code fences.
   try {
     return tryParse(trim.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/u, ""));
-  } catch { /* fall through */ }
+  } catch (e) {
+    logger.debug("Gemini JSON parse (fence-stripped) failed, trying next strategy: {error}", { error: e });
+  }
   // Extract the first {...} block in case the model prepended prose.
   const match = /\{[\s\S]*\}/u.exec(trim);
   if (match) {

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -89,7 +89,7 @@ function parseGeminiTagsJson(text: string): string[] {
 
   for (const [label, extract] of strategies) {
     const candidate = extract();
-    if (candidate === null) continue;
+    if (candidate === null) {continue;}
     try {
       return tryParse(candidate);
     } catch (e) {

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from "@google/genai";
+import { GoogleGenAI, Type } from "@google/genai";
 import { getLogger } from "@logtape/logtape";
 import type { BotConfig } from "./config";
 import type { FeedEntry } from "./rss";
@@ -72,31 +72,11 @@ export function mergeHashtagCandidates(rawStrings: string[], max = MAX_TAGS): st
 }
 
 function parseGeminiTagsJson(text: string): string[] {
-  const trim = text.trim();
-  const tryParse = (s: string): string[] => {
-    const data = JSON.parse(s) as { tags?: unknown };
-    if (!Array.isArray(data.tags)) {
-      throw new Error("missing tags array");
-    }
-    return data.tags.filter((x): x is string => typeof x === "string");
-  };
-
-  const strategies: Array<[string, () => string | null]> = [
-    ["raw", () => trim],
-    ["fence-stripped", () => trim.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/u, "")],
-    ["object-extract", () => /\{[\s\S]*\}/u.exec(trim)?.[0] ?? null],
-  ];
-
-  for (const [label, extract] of strategies) {
-    const candidate = extract();
-    if (candidate === null) {continue;}
-    try {
-      return tryParse(candidate);
-    } catch (e) {
-      logger.debug("Gemini JSON parse ({label}) failed: {error}", { label, error: e });
-    }
+  const data = JSON.parse(text) as { tags?: unknown };
+  if (!Array.isArray(data.tags)) {
+    throw new Error("missing tags array in Gemini response");
   }
-  throw new Error("no JSON object found in Gemini response");
+  return data.tags.filter((x): x is string => typeof x === "string");
 }
 
 async function geminiSuggestMissingTags(params: {
@@ -161,6 +141,16 @@ Respond with JSON only: {"tags":["Tag",...]} with exactly ${need} strings.`;
       maxOutputTokens: 128,
       temperature: 0.3,
       responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          tags: {
+            type: Type.ARRAY,
+            items: { type: Type.STRING },
+          },
+        },
+        required: ["tags"],
+      },
     },
   });
 

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -80,22 +80,21 @@ function parseGeminiTagsJson(text: string): string[] {
     }
     return data.tags.filter((x): x is string => typeof x === "string");
   };
-  // Try raw text first.
-  try {
-    return tryParse(trim);
-  } catch (e) {
-    logger.debug("Gemini JSON parse (raw) failed, trying next strategy: {error}", { error: e });
-  }
-  // Strip markdown code fences.
-  try {
-    return tryParse(trim.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/u, ""));
-  } catch (e) {
-    logger.debug("Gemini JSON parse (fence-stripped) failed, trying next strategy: {error}", { error: e });
-  }
-  // Extract the first {...} block in case the model prepended prose.
-  const match = /\{[\s\S]*\}/u.exec(trim);
-  if (match) {
-    return tryParse(match[0]);
+
+  const strategies: Array<[string, () => string | null]> = [
+    ["raw", () => trim],
+    ["fence-stripped", () => trim.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/u, "")],
+    ["object-extract", () => /\{[\s\S]*\}/u.exec(trim)?.[0] ?? null],
+  ];
+
+  for (const [label, extract] of strategies) {
+    const candidate = extract();
+    if (candidate === null) continue;
+    try {
+      return tryParse(candidate);
+    } catch (e) {
+      logger.debug("Gemini JSON parse ({label}) failed: {error}", { label, error: e });
+    }
   }
   throw new Error("no JSON object found in Gemini response");
 }
@@ -134,20 +133,23 @@ async function geminiSuggestMissingTags(params: {
     },
   };
 
-  const prompt =
-    `You are an experienced social-media content strategist. ` +
-    `Given the JSON below describing a Fediverse mirroring bot and one RSS/Atom item, suggest exactly ${need} distinct hashtags.\n\n` +
-    `Strategy:\n` +
-    `- Analyze the entry title, categories, and bot summary to identify key themes, topics, and sentiments.\n` +
-    `- Curate tags that are varied in popularity: mix broadly trending tags (high reach) with specific niche tags (targeted engagement) so the post is discoverable by both large and focused audiences.\n` +
-    `- Align tags with the bot's identity and typical content (feed URL, display name, summary, default hashtags) to fit its overall social-media strategy.\n\n` +
-    `Format rules:\n` +
-    `- Each tag MUST be a single common word or well-known short compound (e.g. "Tech", "OpenSource", "Science", "Music").\n` +
-    `- Maximum 30 characters per tag. Prefer tags under 15 characters.\n` +
-    `- ASCII letters, digits, underscore only; CamelCase; no # or spaces inside a tag.\n` +
-    `- Use recognizable topic tags, NOT article-specific phrases or proper nouns from the title.\n\n` +
-    `${JSON.stringify(context, null, 2)}\n\n` +
-    `Respond with JSON only: {"tags":["Tag",...]} with exactly ${need} strings.`;
+  const prompt = `You are an experienced social-media content strategist. \
+Given the JSON below describing a Fediverse mirroring bot and one RSS/Atom item, suggest exactly ${need} distinct hashtags.
+
+Strategy:
+- Analyze the entry title, categories, and bot summary to identify key themes, topics, and sentiments.
+- Curate tags that are varied in popularity: mix broadly trending tags (high reach) with specific niche tags (targeted engagement) so the post is discoverable by both large and focused audiences.
+- Align tags with the bot's identity and typical content (feed URL, display name, summary, default hashtags) to fit its overall social-media strategy.
+
+Format rules:
+- Each tag MUST be a single common word or well-known short compound (e.g. "Tech", "OpenSource", "Science", "Music").
+- Maximum 30 characters per tag. Prefer tags under 15 characters.
+- ASCII letters, digits, underscore only; CamelCase; no # or spaces inside a tag.
+- Use recognizable topic tags, NOT article-specific phrases or proper nouns from the title.
+
+${JSON.stringify(context, null, 2)}
+
+Respond with JSON only: {"tags":["Tag",...]} with exactly ${need} strings.`;
 
   const ai = project
     ? new GoogleGenAI({ vertexai: true, project, location: location ?? "us-central1" })
@@ -219,18 +221,10 @@ export async function resolveHashtags(
       bot,
       entry,
     });
-    for (const t of more) {
-      const n = normalizeHashtagLabel(t);
-      if (n) {
-        dedupePush(pool, n);
-      }
-      if (pool.length >= MAX_TAGS) {
-        break;
-      }
-    }
+    return mergeHashtagCandidates([...pool, ...more], MAX_TAGS);
   } catch (e) {
     logger.warn("Gemini hashtag fill failed: {error}", { error: e });
   }
 
-  return pool.slice(0, MAX_TAGS);
+  return pool;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,6 +1074,18 @@
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
   integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
+"@stylistic/eslint-plugin@^5.10.0":
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz#471bbd9f7a27ceaac4a217e7f5b3890855e5640c"
+  integrity sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/types" "^8.56.0"
+    eslint-visitor-keys "^4.2.1"
+    espree "^10.4.0"
+    estraverse "^5.3.0"
+    picomatch "^4.0.3"
+
 "@swc/helpers@0.5.15":
   version "0.5.15"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
@@ -1317,7 +1329,7 @@
     debug "^4.4.3"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/types@8.58.1", "@typescript-eslint/types@^8.58.1":
+"@typescript-eslint/types@8.58.1", "@typescript-eslint/types@^8.56.0", "@typescript-eslint/types@^8.58.1":
   version "8.58.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.58.1.tgz#9dfb4723fcd2b13737d8b03d941354cf73190313"
   integrity sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==
@@ -1420,7 +1432,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.16.0:
+acorn@^8.15.0, acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1741,6 +1753,11 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
+  integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
+
 eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
@@ -1782,6 +1799,15 @@ eslint@^10:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+espree@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-10.4.0.tgz#d54f4949d4629005a1fa168d937c3ff1f7e2a837"
+  integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^4.2.1"
+
 espree@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-11.2.0.tgz#01d5e47dc332aaba3059008362454a8cc34ccaa5"
@@ -1805,7 +1831,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==


### PR DESCRIPTION

When Gemini is configured, feed categories are passed as context in the AI prompt rather than added directly to the hashtag pool. default_hashtags still seed the pool. Without Gemini, falls back to categories + defaults as direct hashtags (existing behavior).

Also renders hashtags inline on each post in the bot profile page.