### PR TITLE
Run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,17 @@ ENV NODE_ENV=production
 ENV PORT=8080
 ENV HOSTNAME="0.0.0.0"
 
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY drizzle/ drizzle/
-COPY feeds.yml ./
+# Create a dedicated non-root user, matching the convention used by
+# all other Next.js services in this stack.
+RUN groupadd --system --gid 1001 nodejs && \
+    useradd --system --uid 1001 --gid nodejs nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --chown=nextjs:nodejs drizzle/ drizzle/
+COPY --chown=nextjs:nodejs feeds.yml ./
+
+USER nextjs
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Problem

The final `FROM node:25-slim` stage had no `USER` directive, so the Next.js server process ran as root (UID 0). This service has database access (PostgreSQL via Drizzle), makes external HTTP requests (RSS feeds, Mastodon, Google Gemini), and handles ActivityPub federation — a high-value target.

**Why this matters**: If an attacker exploits the application (e.g., a path traversal via RSS feed parsing, a SSRF, or a Next.js/Drizzle vulnerability), they immediately gain root inside the container, dramatically increasing the blast radius.

All other Next.js services in the stack (`natwelch.com`, `writing`, `photos`, `realworldsre.com`, `timeclimbers.com`, `etu-web`) already run as non-root. This PR brings `robot.villas` into alignment.

## Fix

```diff
+RUN groupadd --system --gid 1001 nodejs && \
+    useradd --system --uid 1001 --gid nodejs nextjs
+
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY drizzle/ drizzle/
-COPY feeds.yml ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --chown=nextjs:nodejs drizzle/ drizzle/
+COPY --chown=nextjs:nodejs feeds.yml ./
+
+USER nextjs
```

## Testing

```bash
docker build -t robot-villas-test .
docker run --rm robot-villas-test id
# Expected: uid=1001(nextjs) gid=1001(nodejs) ...
```

## Audit Note

**Reviewed**: Dockerfile, package.json, src/, drizzle/  
**Found & fixed**: container running as root  
**Skipped / future run**: The `DATABASE_URL` credential is passed as a plain env var in the compose file — consider moving to a Docker secret. ActivityPub keypairs are stored in the database; ensure DB credentials are rotated regularly.
