### PR TITLE
fix: decode HTML entities in RSS CDATA titles

### DIFF
--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -157,9 +157,10 @@ describe("decodeHtmlEntities", () => {
     expect(decodeHtmlEntities("&hellip;")).toBe("\u2026");
   });
 
-  it("decodes double-encoded ampersand before numeric reference", () => {
-    // &amp;#8217; → &#8217; → '
-    expect(decodeHtmlEntities("&amp;#8217;")).toBe("\u2019");
+  it("decodes &amp; as a single pass (does not double-decode)", () => {
+    // Single pass: &amp;#8217; → &#8217; (the &amp; is decoded to &, but the
+    // resulting &#8217; is not processed again in the same call)
+    expect(decodeHtmlEntities("&amp;#8217;")).toBe("&#8217;");
   });
 
   it("passes through plain text unchanged", () => {

--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  decodeHtmlEntities,
   extractFeedCategories,
   fetchFeedWithHttpResult,
   MAX_ITEMS_PER_POLL,
@@ -114,6 +115,55 @@ describe("parseFeedXml", () => {
     expect(entries).toHaveLength(MAX_ITEMS_PER_POLL);
     expect(entries[0]?.title).toBe("Item 0");
     expect(entries[MAX_ITEMS_PER_POLL - 1]?.title).toBe(`Item ${MAX_ITEMS_PER_POLL - 1}`);
+  });
+
+  it("decodes HTML entities in CDATA titles", async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title><![CDATA[Ikea&#8217;s new inflatable chair doesn&#8217;t look like an inflatable chair]]></title>
+      <link>https://example.com/ikea</link>
+      <guid>ikea-1</guid>
+    </item>
+  </channel>
+</rss>`;
+    const entries = await parseFeedXml(xml);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.title).toBe("Ikea\u2019s new inflatable chair doesn\u2019t look like an inflatable chair");
+  });
+});
+
+describe("decodeHtmlEntities", () => {
+  it("decodes decimal numeric character references", () => {
+    expect(decodeHtmlEntities("Ikea&#8217;s")).toBe("Ikea\u2019s");
+    expect(decodeHtmlEntities("&#169; 2024")).toBe("\u00A9 2024");
+  });
+
+  it("decodes hex numeric character references", () => {
+    expect(decodeHtmlEntities("&#x2019;s")).toBe("\u2019s");
+    expect(decodeHtmlEntities("&#X2019;s")).toBe("\u2019s");
+  });
+
+  it("decodes common named entities", () => {
+    expect(decodeHtmlEntities("AT&amp;T")).toBe("AT&T");
+    expect(decodeHtmlEntities("&lt;b&gt;")).toBe("<b>");
+    expect(decodeHtmlEntities("&quot;quoted&quot;")).toBe('"quoted"');
+    expect(decodeHtmlEntities("&apos;")).toBe("'");
+    expect(decodeHtmlEntities("foo&nbsp;bar")).toBe("foo\u00A0bar");
+    expect(decodeHtmlEntities("&mdash;")).toBe("\u2014");
+    expect(decodeHtmlEntities("&hellip;")).toBe("\u2026");
+  });
+
+  it("decodes double-encoded ampersand before numeric reference", () => {
+    // &amp;#8217; → &#8217; → '
+    expect(decodeHtmlEntities("&amp;#8217;")).toBe("\u2019");
+  });
+
+  it("passes through plain text unchanged", () => {
+    expect(decodeHtmlEntities("Hello world")).toBe("Hello world");
+    expect(decodeHtmlEntities("")).toBe("");
   });
 });
 

--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -4,6 +4,7 @@ import {
   extractFeedCategories,
   fetchFeedWithHttpResult,
   MAX_ITEMS_PER_POLL,
+  normalizeTypography,
   parseFeedXml,
   type FeedEntry,
 } from "../rss";
@@ -117,7 +118,7 @@ describe("parseFeedXml", () => {
     expect(entries[MAX_ITEMS_PER_POLL - 1]?.title).toBe(`Item ${MAX_ITEMS_PER_POLL - 1}`);
   });
 
-  it("decodes HTML entities in CDATA titles", async () => {
+  it("decodes HTML entities in CDATA titles and normalizes to ASCII", async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
   <channel>
@@ -131,7 +132,7 @@ describe("parseFeedXml", () => {
 </rss>`;
     const entries = await parseFeedXml(xml);
     expect(entries).toHaveLength(1);
-    expect(entries[0]?.title).toBe("Ikea\u2019s new inflatable chair doesn\u2019t look like an inflatable chair");
+    expect(entries[0]?.title).toBe("Ikea's new inflatable chair doesn't look like an inflatable chair");
   });
 });
 
@@ -164,6 +165,38 @@ describe("decodeHtmlEntities", () => {
   it("passes through plain text unchanged", () => {
     expect(decodeHtmlEntities("Hello world")).toBe("Hello world");
     expect(decodeHtmlEntities("")).toBe("");
+  });
+});
+
+describe("normalizeTypography", () => {
+  it("replaces curly single quotes and apostrophes with ASCII apostrophe", () => {
+    expect(normalizeTypography("\u2018hello\u2019")).toBe("'hello'");
+    expect(normalizeTypography("Ikea\u2019s")).toBe("Ikea's");
+  });
+
+  it("replaces curly double quotes with ASCII double quote", () => {
+    expect(normalizeTypography("\u201Chello\u201D")).toBe('"hello"');
+  });
+
+  it("replaces en dash with hyphen", () => {
+    expect(normalizeTypography("2020\u20132021")).toBe("2020-2021");
+  });
+
+  it("replaces em dash with double hyphen", () => {
+    expect(normalizeTypography("foo\u2014bar")).toBe("foo--bar");
+  });
+
+  it("replaces ellipsis with three dots", () => {
+    expect(normalizeTypography("wait\u2026")).toBe("wait...");
+  });
+
+  it("replaces non-breaking space with regular space", () => {
+    expect(normalizeTypography("foo\u00A0bar")).toBe("foo bar");
+  });
+
+  it("passes through plain ASCII unchanged", () => {
+    expect(normalizeTypography("Hello, world!")).toBe("Hello, world!");
+    expect(normalizeTypography("")).toBe("");
   });
 });
 

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -2,32 +2,25 @@ import Parser from "rss-parser";
 
 const parser = new Parser({ timeout: 10_000 });
 
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&", lt: "<", gt: ">", quot: '"', apos: "'",
+  nbsp: "\u00A0", ndash: "\u2013", mdash: "\u2014",
+  lsquo: "\u2018", rsquo: "\u2019", ldquo: "\u201C", rdquo: "\u201D",
+  hellip: "\u2026",
+};
+
 /**
- * Decodes HTML entities from a string. Needed because rss-parser returns raw
- * CDATA content without decoding HTML entities (e.g. &#8217; stays as-is
- * instead of becoming the curly apostrophe ʼ). Without this, escapeHtml()
- * double-encodes the ampersand, causing Mastodon to display raw entity strings.
+ * Decodes HTML entities from a string in a single pass. Needed because
+ * rss-parser returns raw CDATA content without decoding HTML entities
+ * (e.g. &#8217; stays as-is). Without this, escapeHtml() double-encodes
+ * the ampersand, causing Mastodon to display raw entity strings like &#8217;.
  */
 export function decodeHtmlEntities(str: string): string {
-  return str
-    // Named entities (process before numeric so &amp;#8217; → &#8217; → ')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&nbsp;/g, "\u00A0")
-    .replace(/&ndash;/g, "\u2013")
-    .replace(/&mdash;/g, "\u2014")
-    .replace(/&lsquo;/g, "\u2018")
-    .replace(/&rsquo;/g, "\u2019")
-    .replace(/&ldquo;/g, "\u201C")
-    .replace(/&rdquo;/g, "\u201D")
-    .replace(/&hellip;/g, "\u2026")
-    // Decimal numeric character references (e.g. &#8217; → ')
-    .replace(/&#(\d+);/g, (_, dec: string) => String.fromCodePoint(parseInt(dec, 10)))
-    // Hex numeric character references (e.g. &#x2019; → ')
-    .replace(/&#x([0-9a-fA-F]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)));
+  return str.replace(/&(?:#(\d+)|#x([0-9a-fA-F]+)|([a-zA-Z]+));/gi, (match, dec, hex, name) => {
+    if (dec) return String.fromCodePoint(parseInt(dec, 10));
+    if (hex) return String.fromCodePoint(parseInt(hex, 16));
+    return NAMED_ENTITIES[name.toLowerCase()] ?? match;
+  });
 }
 
 /** Replaces Unicode typographic characters with plain ASCII equivalents. */

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -18,11 +18,11 @@ const NAMED_ENTITIES: Record<string, string> = {
 export function decodeHtmlEntities(str: string): string {
   return str.replace(/&(?:#(\d+)|#x([0-9a-fA-F]+)|([a-zA-Z]+));/gi, (match, dec, hex, name) => {
     if (dec) {
-return String.fromCodePoint(parseInt(dec, 10));
-}
+      return String.fromCodePoint(parseInt(dec, 10));
+    }
     if (hex) {
-return String.fromCodePoint(parseInt(hex, 16));
-}
+      return String.fromCodePoint(parseInt(hex, 16));
+    }
     return NAMED_ENTITIES[name.toLowerCase()] ?? match;
   });
 }

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -30,6 +30,17 @@ export function decodeHtmlEntities(str: string): string {
     .replace(/&#x([0-9a-fA-F]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)));
 }
 
+/** Replaces Unicode typographic characters with plain ASCII equivalents. */
+export function normalizeTypography(str: string): string {
+  return str
+    .replace(/[\u2018\u2019\u201A\u201B\u2032\u2035]/g, "'")  // curly single quotes, apostrophes, primes
+    .replace(/[\u201C\u201D\u201E\u201F\u2033\u2036]/g, '"')  // curly double quotes, double primes
+    .replace(/\u2013/g, "-")                                   // en dash
+    .replace(/\u2014/g, "--")                                  // em dash
+    .replace(/\u2026/g, "...")                                 // ellipsis
+    .replace(/\u00A0/g, " ");                                  // non-breaking space
+}
+
 const FEED_FETCH_TIMEOUT_MS = 10_000;
 
 /** Max items to process per feed per poll; limits DoS from huge feeds. */
@@ -135,7 +146,7 @@ export function extractFeedCategories(item: Parser.Item): string[] {
 function normalizeFeedItem(item: Parser.Item): FeedEntry {
   const raw = item as Record<string, unknown>;
   const guid = item.guid || (raw.id as string | undefined) || item.link || item.title || "";
-  const title = decodeHtmlEntities(item.title || "(untitled)");
+  const title = normalizeTypography(decodeHtmlEntities(item.title || "(untitled)"));
   const link = item.link || "";
   const publishedAt = item.isoDate ? new Date(item.isoDate) : null;
   return { guid, title, link, publishedAt, feedCategories: extractFeedCategories(item) };

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -2,6 +2,34 @@ import Parser from "rss-parser";
 
 const parser = new Parser({ timeout: 10_000 });
 
+/**
+ * Decodes HTML entities from a string. Needed because rss-parser returns raw
+ * CDATA content without decoding HTML entities (e.g. &#8217; stays as-is
+ * instead of becoming the curly apostrophe ʼ). Without this, escapeHtml()
+ * double-encodes the ampersand, causing Mastodon to display raw entity strings.
+ */
+export function decodeHtmlEntities(str: string): string {
+  return str
+    // Named entities (process before numeric so &amp;#8217; → &#8217; → ')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, "\u00A0")
+    .replace(/&ndash;/g, "\u2013")
+    .replace(/&mdash;/g, "\u2014")
+    .replace(/&lsquo;/g, "\u2018")
+    .replace(/&rsquo;/g, "\u2019")
+    .replace(/&ldquo;/g, "\u201C")
+    .replace(/&rdquo;/g, "\u201D")
+    .replace(/&hellip;/g, "\u2026")
+    // Decimal numeric character references (e.g. &#8217; → ')
+    .replace(/&#(\d+);/g, (_, dec: string) => String.fromCodePoint(parseInt(dec, 10)))
+    // Hex numeric character references (e.g. &#x2019; → ')
+    .replace(/&#x([0-9a-fA-F]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)));
+}
+
 const FEED_FETCH_TIMEOUT_MS = 10_000;
 
 /** Max items to process per feed per poll; limits DoS from huge feeds. */
@@ -107,7 +135,7 @@ export function extractFeedCategories(item: Parser.Item): string[] {
 function normalizeFeedItem(item: Parser.Item): FeedEntry {
   const raw = item as Record<string, unknown>;
   const guid = item.guid || (raw.id as string | undefined) || item.link || item.title || "";
-  const title = item.title || "(untitled)";
+  const title = decodeHtmlEntities(item.title || "(untitled)");
   const link = item.link || "";
   const publishedAt = item.isoDate ? new Date(item.isoDate) : null;
   return { guid, title, link, publishedAt, feedCategories: extractFeedCategories(item) };

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -17,8 +17,12 @@ const NAMED_ENTITIES: Record<string, string> = {
  */
 export function decodeHtmlEntities(str: string): string {
   return str.replace(/&(?:#(\d+)|#x([0-9a-fA-F]+)|([a-zA-Z]+));/gi, (match, dec, hex, name) => {
-    if (dec) return String.fromCodePoint(parseInt(dec, 10));
-    if (hex) return String.fromCodePoint(parseInt(hex, 16));
+    if (dec) {
+return String.fromCodePoint(parseInt(dec, 10));
+}
+    if (hex) {
+return String.fromCodePoint(parseInt(hex, 16));
+}
     return NAMED_ENTITIES[name.toLowerCase()] ?? match;
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,15 +25,7 @@
   resolved "https://registry.yarnpkg.com/@drizzle-team/brocli/-/brocli-0.10.2.tgz#9757c006a43daaa6f45512e6cf5fabed36fb9da7"
   integrity sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==
 
-"@emnapi/core@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
-  integrity sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.1"
-    tslib "^2.4.0"
-
-"@emnapi/core@^1.8.1":
+"@emnapi/core@1.10.0", "@emnapi/core@^1.8.1":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
   integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
@@ -41,14 +33,7 @@
     "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
-"@emnapi/runtime@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.2.tgz#8b469a3db160817cadb1de9050211a9d1ea84fa2"
-  integrity sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.7.0", "@emnapi/runtime@^1.8.1":
+"@emnapi/runtime@1.10.0", "@emnapi/runtime@^1.7.0", "@emnapi/runtime@^1.8.1":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
   integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
@@ -262,13 +247,13 @@
     levn "^0.4.1"
 
 "@fedify/fedify@^2.1.3":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-2.1.9.tgz#a9e574e7ad1fa530d7fc57c92215ab8e7b0806d3"
-  integrity sha512-qxi6kpvBf28hay1cNqlkYrj8boj8f/NgGGFgydF6VjQ0d5qPML3rAsFkTtEZusedP0ik2h8Tn97EOODSeud9Xw==
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-2.1.10.tgz#ff4fb65deebf7584f046e030c1a63754dca99c13"
+  integrity sha512-tjJ+wOnjqLGA6wA6BJnNrckKuFSk0X4wofYEA4bWVdlx844VOnT7BDwlEQ/D0SACYijQgp/h5annBOWIG/HFsQ==
   dependencies:
-    "@fedify/vocab" "2.1.9"
-    "@fedify/vocab-runtime" "2.1.9"
-    "@fedify/webfinger" "2.1.9"
+    "@fedify/vocab" "2.1.10"
+    "@fedify/vocab-runtime" "2.1.10"
+    "@fedify/webfinger" "2.1.10"
     "@js-temporal/polyfill" "^0.5.1"
     "@logtape/logtape" "^2.0.5"
     "@opentelemetry/api" "^1.9.0"
@@ -285,22 +270,22 @@
     urlpattern-polyfill "^10.1.0"
 
 "@fedify/next@^2.1.3":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/next/-/next-2.1.9.tgz#5739de55a7f48a15c835dcc3604dc57ac6d69268"
-  integrity sha512-WQL6JDKjMMfnJqiFHNYwU1dQ/10flouakZp2mYj/8Z901V+O98Fh6DYL0ozYGU0/pvLjhPrnxML3FKBzmHzboQ==
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/next/-/next-2.1.10.tgz#720bdf44ac114d90dfac33425f15a7fe1a62c0fe"
+  integrity sha512-IQpnN9CJukG2wBDSsJMAKnV5EuOtyvQdA6pM2aw2v85AVIUeag6nzh8u8t1G6nHpxiGnNLZNXWNrdIpKS3Dlxw==
 
 "@fedify/postgres@^2.1.3":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/postgres/-/postgres-2.1.9.tgz#2c6baf70ce412102300eac02fbf911df7aea903b"
-  integrity sha512-CdzHkK99uQcyp59H9LvvJftu7Qm7GqK5m/vfw5g0pti9stNCxzBEOMHZyLL5qcHIK1MC377mvA2tAG0Fuq2z/Q==
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/postgres/-/postgres-2.1.10.tgz#b65094b3a6e4bf2a2a80d44e192a0b37af914484"
+  integrity sha512-QxvIXD4dloyp6MUVN7GiliN4otS2haRs257xn8whG1aGhJo52oR91e0kgqM28LwAlwd9Zrf9gPN5prnvWLEz2w==
   dependencies:
     "@js-temporal/polyfill" "^0.5.1"
     "@logtape/logtape" "^2.0.5"
 
-"@fedify/vocab-runtime@2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/vocab-runtime/-/vocab-runtime-2.1.9.tgz#c83a792376d16ad43c1d18438b2b5f4b5f9c34df"
-  integrity sha512-YngIWoPylaes56sWdBLoOCrZcK6P6PihvQRkDhbllGDTVkduxa/WC3Ko1MWwS+CXpUF3oTMv88sVoJb7SeajHA==
+"@fedify/vocab-runtime@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/vocab-runtime/-/vocab-runtime-2.1.10.tgz#9c8081c58bd624f3065269578387c6eb000356e9"
+  integrity sha512-R8+oqw2tA1cI1I6aeoIkef97tTR1Co1UrdaAk764vQm5dYscKYVZk7ENbMHu3B60Cc3gyLiJGZcL9stuFpDtnw==
   dependencies:
     "@logtape/logtape" "^2.0.5"
     "@multiformats/base-x" "^4.0.1"
@@ -310,24 +295,24 @@
     jsonld "^9.0.0"
     pkijs "^3.3.3"
 
-"@fedify/vocab-tools@2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/vocab-tools/-/vocab-tools-2.1.9.tgz#698402a4153c634be5cd4c313ace2b4163817570"
-  integrity sha512-iVcSpM7JQvbRc18zQ9MBdPdvW1BiQhQT+hv8WXPgLcUXfU7+tpBQO+mOg39ERMQexbLFJ5CkdUNtHuOp5Ytp+Q==
+"@fedify/vocab-tools@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/vocab-tools/-/vocab-tools-2.1.10.tgz#24603ea383857a02f252d9642c42781c23d2bdbf"
+  integrity sha512-MMhh2a/mzdAHT1vJiJbt7LwZPVwrXFQmuPv1wyOdGyL9fLtkjRh7IwLRTj25Lq61g2xjZDhJnArwbK6MFBNviQ==
   dependencies:
     "@cfworker/json-schema" "^4.1.1"
     byte-encodings "^1.0.11"
     es-toolkit "^1.39.10"
     yaml "^2.8.1"
 
-"@fedify/vocab@2.1.9", "@fedify/vocab@^2.0.0":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/vocab/-/vocab-2.1.9.tgz#e8363e373686a152a7078dc0e6099e894eb130c3"
-  integrity sha512-Hr0VfJVKTUp26/vwi8MyI3iHPwpzhPjuP9yVn8fcOADFnqXXcXtPRUjnHuLA0+vgzNhyx5Oggxd0wQUTcNCNUQ==
+"@fedify/vocab@2.1.10", "@fedify/vocab@^2.0.0":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/vocab/-/vocab-2.1.10.tgz#f162d63b26c51d8863259f768606e73aad926d84"
+  integrity sha512-YhFBPM1/JYLvzuQzggCJnbrrMLFU0Um55CJSJX0w70Nbxh0MQgfUe1GV2XlXmHepVuf6XQJaPK2YJrCpKb0M9A==
   dependencies:
-    "@fedify/vocab-runtime" "2.1.9"
-    "@fedify/vocab-tools" "2.1.9"
-    "@fedify/webfinger" "2.1.9"
+    "@fedify/vocab-runtime" "2.1.10"
+    "@fedify/vocab-tools" "2.1.10"
+    "@fedify/webfinger" "2.1.10"
     "@js-temporal/polyfill" "^0.5.1"
     "@logtape/logtape" "^2.0.5"
     "@multiformats/base-x" "^4.0.1"
@@ -337,12 +322,12 @@
     jsonld "^9.0.0"
     pkijs "^3.3.3"
 
-"@fedify/webfinger@2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@fedify/webfinger/-/webfinger-2.1.9.tgz#503796725ff5c6c24ea66bc8d63c03b3b5fe04a9"
-  integrity sha512-W+4NeITleUXSUCy/1dCwaUuI5pd96CXEkGAag3IqDqO82zQtH7ak09wXluougTVZ1f5HLcHmokK8W6bi+MjPQw==
+"@fedify/webfinger@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@fedify/webfinger/-/webfinger-2.1.10.tgz#de8b65bf43ff35dcf8261df0ebc32e25e265abef"
+  integrity sha512-Yfbh+PWQBu5GsKMmoEaWxJ19T7/qagm1uutP21dV/5kbVTsMcXUie+FmWbhb8AwDcaviMQr0jVKAwMh2UvCgDA==
   dependencies:
-    "@fedify/vocab-runtime" "2.1.9"
+    "@fedify/vocab-runtime" "2.1.10"
     "@logtape/logtape" "^2.0.5"
     "@opentelemetry/api" "^1.9.0"
     es-toolkit "1.43.0"
@@ -710,10 +695,10 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
 
-"@oxc-project/types@=0.126.0":
-  version "0.126.0"
-  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.126.0.tgz#9d9fa6fe9af5bc6c45996c6d9b9a3b3a4cd500e5"
-  integrity sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==
+"@oxc-project/types@=0.127.0":
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.127.0.tgz#8374fcdfb4a641861218daa5700c447c00b66663"
+  integrity sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -768,89 +753,89 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@rolldown/binding-android-arm64@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz#9af7872d363738e7a2aaa1c1be8cad57adf75798"
-  integrity sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==
+"@rolldown/binding-android-arm64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz#0a502a88c39d0ffa81aa30b561dade6f6217dcc5"
+  integrity sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==
 
-"@rolldown/binding-darwin-arm64@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz#88f394f20c664ac2c51fe5d5d364b94bbf8ef430"
-  integrity sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==
+"@rolldown/binding-darwin-arm64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz#8b7f05ac9000ab19161a79a0346b1b64a1bc7ba3"
+  integrity sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==
 
-"@rolldown/binding-darwin-x64@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz#d5350b1d3d13fddb1bc5abb00cadc07787a5d6fa"
-  integrity sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==
+"@rolldown/binding-darwin-x64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz#f8b465b3a4e992053890b162f1ae19e4f1719a6a"
+  integrity sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==
 
-"@rolldown/binding-freebsd-x64@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz#116fe2b906ef658e913bd1419775114dee97c35f"
-  integrity sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==
+"@rolldown/binding-freebsd-x64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz#a8281e14fa9c243fe22dc2d0e54900e66b31935e"
+  integrity sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==
 
-"@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz#3a72b393936c580b40aa66230cdc30ac20fb0409"
-  integrity sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==
+"@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz#cd29cf869ddd4fac8d6929abf94b91ddb0494650"
+  integrity sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==
 
-"@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz#3ec9b2dce7b5c29d37272fa3a1aee6159badfb76"
-  integrity sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==
+"@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz#91c331236ec3728366218d61a62f0bd226546c6c"
+  integrity sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==
 
-"@rolldown/binding-linux-arm64-musl@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz#4103d75b7e7f2650d32fef0df01ff5441657b6ee"
-  integrity sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==
+"@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz#80108957db752e7826836e22240e56b8140e9684"
+  integrity sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==
 
-"@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz#4bff51a9d0c4c5ec402ac10f41cef22d6a21889c"
-  integrity sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==
+"@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz#1dce51148cbc6bab3c3f9157b5323d2a31aac924"
+  integrity sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==
 
-"@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz#7b9399eda0b2e49c7e5d2b98172196565de3709f"
-  integrity sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==
+"@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz#d4a0d2e01d8d441e4ac3af3fa68eec17a7d0e9cd"
+  integrity sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==
 
-"@rolldown/binding-linux-x64-gnu@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz#82b64f4c9aa018718c27a11fc5f8e9141f1c3276"
-  integrity sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==
+"@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz#0ac8b3139cefeea798ad147f30ea70572b133af1"
+  integrity sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==
 
-"@rolldown/binding-linux-x64-musl@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz#710c4bf32715d5564fd7bb39bfbe9195f0e8b9a6"
-  integrity sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==
+"@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz#2af61bee087571728f58f1c47734bbbd41dd7050"
+  integrity sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==
 
-"@rolldown/binding-openharmony-arm64@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz#ab5cc4736ff363c4fad67c017edf4634c036e82a"
-  integrity sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==
+"@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz#56c1afbf6c592819abf47b4a983987dc288b30c1"
+  integrity sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==
 
-"@rolldown/binding-wasm32-wasi@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz#906dec98ca584cec655a336fca870ac7095fbe93"
-  integrity sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==
+"@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz#5d112ff4dd0d268a60fb4e0eb3077e3ea2531f0d"
+  integrity sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==
   dependencies:
-    "@emnapi/core" "1.9.2"
-    "@emnapi/runtime" "1.9.2"
+    "@emnapi/core" "1.10.0"
+    "@emnapi/runtime" "1.10.0"
     "@napi-rs/wasm-runtime" "^1.1.4"
 
-"@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz#19dd3cf898727fad4f9209cf2aae829a789a9348"
-  integrity sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==
+"@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz#5125a85222d64a543201d28e16a395cc45bf4d17"
+  integrity sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==
 
-"@rolldown/binding-win32-x64-msvc@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz#94f8930ac50d62c5d9a1a14855125aa945a14234"
-  integrity sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==
+"@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz#fc6b78e759a0bb2054b5c0a3489da12b2cae54b4"
+  integrity sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==
 
-"@rolldown/pluginutils@1.0.0-rc.16":
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz#bc27c8f906309b57c6c10eddb21043fd8e86b87e"
-  integrity sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==
+"@rolldown/pluginutils@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz#a89b30833fb628bc834fe2e89fea93a2da9fa69a"
+  integrity sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -1226,9 +1211,9 @@ agent-base@^7.1.2:
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ajv@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
-  integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1392,12 +1377,12 @@ ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
     safe-buffer "^5.0.1"
 
 enhanced-resolve@^5.19.0:
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz#eeeb3966bea62c348c40a0cc9e7912e2557d0be0"
-  integrity sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==
+  version "5.21.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz#bb8e6fabaf74930de70e61397798750429e5b1ae"
+  integrity sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==
   dependencies:
     graceful-fs "^4.2.4"
-    tapable "^2.3.0"
+    tapable "^2.3.3"
 
 entities@^2.0.3:
   version "2.2.0"
@@ -2229,29 +2214,29 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
-rolldown@1.0.0-rc.16:
-  version "1.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.0-rc.16.tgz#47c1e6b088be3f531a9aacbdb8a90e2255f02702"
-  integrity sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==
+rolldown@1.0.0-rc.17:
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.0-rc.17.tgz#c524fc22f6bb37b5588aec862ab1ee11382610f3"
+  integrity sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==
   dependencies:
-    "@oxc-project/types" "=0.126.0"
-    "@rolldown/pluginutils" "1.0.0-rc.16"
+    "@oxc-project/types" "=0.127.0"
+    "@rolldown/pluginutils" "1.0.0-rc.17"
   optionalDependencies:
-    "@rolldown/binding-android-arm64" "1.0.0-rc.16"
-    "@rolldown/binding-darwin-arm64" "1.0.0-rc.16"
-    "@rolldown/binding-darwin-x64" "1.0.0-rc.16"
-    "@rolldown/binding-freebsd-x64" "1.0.0-rc.16"
-    "@rolldown/binding-linux-arm-gnueabihf" "1.0.0-rc.16"
-    "@rolldown/binding-linux-arm64-gnu" "1.0.0-rc.16"
-    "@rolldown/binding-linux-arm64-musl" "1.0.0-rc.16"
-    "@rolldown/binding-linux-ppc64-gnu" "1.0.0-rc.16"
-    "@rolldown/binding-linux-s390x-gnu" "1.0.0-rc.16"
-    "@rolldown/binding-linux-x64-gnu" "1.0.0-rc.16"
-    "@rolldown/binding-linux-x64-musl" "1.0.0-rc.16"
-    "@rolldown/binding-openharmony-arm64" "1.0.0-rc.16"
-    "@rolldown/binding-wasm32-wasi" "1.0.0-rc.16"
-    "@rolldown/binding-win32-arm64-msvc" "1.0.0-rc.16"
-    "@rolldown/binding-win32-x64-msvc" "1.0.0-rc.16"
+    "@rolldown/binding-android-arm64" "1.0.0-rc.17"
+    "@rolldown/binding-darwin-arm64" "1.0.0-rc.17"
+    "@rolldown/binding-darwin-x64" "1.0.0-rc.17"
+    "@rolldown/binding-freebsd-x64" "1.0.0-rc.17"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-musl" "1.0.0-rc.17"
+    "@rolldown/binding-linux-ppc64-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-s390x-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-musl" "1.0.0-rc.17"
+    "@rolldown/binding-openharmony-arm64" "1.0.0-rc.17"
+    "@rolldown/binding-wasm32-wasi" "1.0.0-rc.17"
+    "@rolldown/binding-win32-arm64-msvc" "1.0.0-rc.17"
+    "@rolldown/binding-win32-x64-msvc" "1.0.0-rc.17"
 
 rss-parser@^3.13.0:
   version "3.13.0"
@@ -2389,7 +2374,7 @@ tailwindcss@4.2.4, tailwindcss@^4:
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.2.4.tgz#f7e3090edb22d56394db4d68e6464d2628dc2aa9"
   integrity sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==
 
-tapable@^2.3.0:
+tapable@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
@@ -2499,14 +2484,14 @@ urlpattern-polyfill@^10.1.0:
   integrity sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==
 
 "vite@^6.0.0 || ^7.0.0 || ^8.0.0":
-  version "8.0.9"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.9.tgz#69602329ebcea1f281124735a1113be51c45d1da"
-  integrity sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==
+  version "8.0.10"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.10.tgz#fb31868526ec874101fac084172a2cdc6776319b"
+  integrity sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==
   dependencies:
     lightningcss "^1.32.0"
     picomatch "^4.0.4"
     postcss "^8.5.10"
-    rolldown "1.0.0-rc.16"
+    rolldown "1.0.0-rc.17"
     tinyglobby "^0.2.16"
   optionalDependencies:
     fsevents "~2.3.3"


### PR DESCRIPTION
## Summary

RSS feeds (e.g. The Verge) wrap titles in \`<![CDATA[...]]>\` sections and embed HTML entities like \`&#8217;\` (right single quotation mark) inside them. \`rss-parser\` / \`xml2js\` does **not** decode HTML entities inside CDATA — it's raw character data. Those literal entity strings then hit \`escapeHtml()\`, which converts \`&\` → \`&amp;\`, producing \`&amp;#8217;\` in the ActivityPub Note HTML. Mastodon renders that as the text \`&#8217;\` instead of the intended character.

### Changes

- **Decode HTML entities in RSS CDATA titles** — adds \`decodeHtmlEntities()\` that handles decimal (\`&#8217;\`), hex (\`&#x2019;\`), and common named entities (\`&amp;\`, \`&rsquo;\`, \`&mdash;\`, \`&hellip;\`, etc.) in a single regex pass. Applied to every RSS title at parse time before anything else touches it.

- **Normalize smart quotes and fancy typography to ASCII** — adds \`normalizeTypography()\` that maps Unicode typographic characters to plain ASCII equivalents:
  - \`'\` \`'\` → \`'\`
  - \`"\` \`"\` → \`"\`
  - \`–\` → \`-\`
  - \`—\` → \`--\`
  - \`…\` → \`...\`
  - Non-breaking space → regular space

- **Single-pass entity decode** — rewrote \`decodeHtmlEntities()\` as one \`replace()\` call over all entity types to address CodeQL's double-unescaping warning from the original chained replacements.

### Before / after

Before: `Ikea&#8217;s new inflatable chair doesn&#8217;t look like an inflatable chair`

After: `Ikea's new inflatable chair doesn't look like an inflatable chair`
