### PR TITLE
fix: handle Reject activities for relay and account follows

### DIFF
--- a/scripts/resubscribe-relays.ts
+++ b/scripts/resubscribe-relays.ts
@@ -1,0 +1,75 @@
+/**
+ * Resets relay subscriptions so they are re-attempted on the next restart.
+ *
+ * Usage:
+ *   DATABASE_URL=... yarn tsx scripts/resubscribe-relays.ts [relay-url ...]
+ *
+ * With no arguments, resets ALL pending and rejected relay subscriptions.
+ * Pass one or more relay URLs to target specific relays, e.g.:
+ *   DATABASE_URL=... yarn tsx scripts/resubscribe-relays.ts \
+ *     https://relay.toot.io/actor \
+ *     https://relay.intahnet.co.uk/actor
+ *
+ * After running, restart the server — subscribeToRelays() will re-send
+ * fresh Follow activities for every reset row.
+ *
+ * Note: if a relay previously sent a Reject (meaning it still has the old
+ * subscription in its own DB), you may also need to contact the relay admin
+ * to remove the stale subscription on their end, or send Undo(Follow) first.
+ */
+
+import postgres from "postgres";
+import { and, eq, inArray, isNull, or } from "drizzle-orm";
+import { createDb } from "../src/lib/db";
+import * as schema from "../src/lib/schema";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.error("DATABASE_URL is not set");
+  process.exit(1);
+}
+
+const targetUrls = process.argv.slice(2);
+
+const client = postgres(databaseUrl);
+const db = createDb(client);
+
+const conditions = [
+  isNull(schema.relays.deletedAt),
+  or(eq(schema.relays.status, "pending"), eq(schema.relays.status, "rejected"))!,
+];
+
+if (targetUrls.length > 0) {
+  conditions.push(inArray(schema.relays.url, targetUrls));
+  console.log(`Resetting relay subscriptions for: ${targetUrls.join(", ")}`);
+} else {
+  console.log("Resetting ALL pending and rejected relay subscriptions...");
+}
+
+const rows = await db
+  .select({
+    botUsername: schema.relays.botUsername,
+    url: schema.relays.url,
+    status: schema.relays.status,
+  })
+  .from(schema.relays)
+  .where(and(...conditions));
+
+if (rows.length === 0) {
+  console.log("No matching relay subscriptions found.");
+  await client.end();
+  process.exit(0);
+}
+
+console.log(`Found ${rows.length} row(s) to reset:`);
+for (const row of rows) {
+  console.log(`  ${row.botUsername} -> ${row.url} (${row.status})`);
+}
+
+await db
+  .update(schema.relays)
+  .set({ deletedAt: new Date() })
+  .where(and(...conditions));
+
+console.log(`Done. Restart the server to trigger fresh Follow activities.`);
+await client.end();

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -539,6 +539,19 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
       await updateFollowingStatus(db, followIdHref, "accepted");
       logger.info("Accepted Follow {followId}", { followId: followIdHref });
     })
+    .on(Reject, async (ctx, reject) => {
+      const object = await reject.getObject(ctx);
+      if (!(object instanceof Follow) || !object.id) {
+        return;
+      }
+      const followIdHref = object.id.href;
+      await updateRelayStatus(db, followIdHref, "rejected");
+      await updateFollowingStatus(db, followIdHref, "rejected");
+      logger.warn("Follow {followId} was rejected by {actor}", {
+        followId: followIdHref,
+        actor: reject.actorId?.href,
+      });
+    })
     .on(Announce, async (ctx, announce) => {
       const ref = parseNoteRef(ctx, announce.objectId, botUsernames, "Announce");
       if (!ref) {


### PR DESCRIPTION
## Summary

- Relay servers (confirmed: `relay.intahnet.co.uk` running yukimochi/Activity-Relay) send explicit `Reject` activities when they bounce a Follow subscription request — e.g. when they already have that actor in their subscriber list from a previous Follow.
- Without a `Reject` handler, Fedify logged `Unsupported activity type` and the DB row stayed `pending` forever, causing the same Follow to be re-sent on every restart.
- This PR adds a `.on(Reject, ...)` handler that mirrors the Accept handler: resolves the embedded Follow object, then marks the matching relay/following row as `"rejected"` so it's skipped on future retries.

## Root cause context

When investigating why relay subscriptions were stuck pending, logs showed each of the pending-relay bots receiving one inbound `Reject` activity per bot ~90 seconds after startup. These were being dropped silently as an unrecognized type. The Rejects appear to come from relays that already have robot.villas bots in their subscriber list (from the original Follow, whose Accept was apparently lost), and are rejecting the re-sent Follow as a duplicate.
