### PR TITLE
fix: use as:Public as Follow object for ActivityRelay subscription

### DIFF
--- a/drizzle/0012_aspiring_tiger_shark.sql
+++ b/drizzle/0012_aspiring_tiger_shark.sql
@@ -1,8 +1,9 @@
 -- Custom SQL migration file, put your code below! --
 
--- Reset rejected relay subscriptions to pending so they are retried on next startup.
+-- Drop rejected relay subscriptions so they are retried on next startup.
 -- Previously, Follow activities used object=<relay-actor-url> which ActivityRelay
 -- interprets as a LitePub peer-relay request (rejected unless sender URL ends in /relay).
--- The correct format is object=PUBLIC_COLLECTION (as:Public). After resetting to pending,
--- the fixed code will re-send the Follow with the correct object on next deploy.
-UPDATE relays SET status = 'pending' WHERE status = 'rejected' AND deleted_at IS NULL;
+-- The correct format is object=PUBLIC_COLLECTION (as:Public). Deleting the rejected rows
+-- means subscribeToRelays will see no existing entry and call upsertRelay, which inserts
+-- a fresh row (status=pending) with the new correctly-formatted Follow activity ID.
+DELETE FROM relays WHERE status = 'rejected' AND deleted_at IS NULL;

--- a/drizzle/0012_aspiring_tiger_shark.sql
+++ b/drizzle/0012_aspiring_tiger_shark.sql
@@ -1,3 +1,5 @@
+-- Custom SQL migration file, put your code below! --
+
 -- Reset rejected relay subscriptions to pending so they are retried on next startup.
 -- Previously, Follow activities used object=<relay-actor-url> which ActivityRelay
 -- interprets as a LitePub peer-relay request (rejected unless sender URL ends in /relay).

--- a/drizzle/0012_reset_rejected_relays.sql
+++ b/drizzle/0012_reset_rejected_relays.sql
@@ -1,0 +1,6 @@
+-- Reset rejected relay subscriptions to pending so they are retried on next startup.
+-- Previously, Follow activities used object=<relay-actor-url> which ActivityRelay
+-- interprets as a LitePub peer-relay request (rejected unless sender URL ends in /relay).
+-- The correct format is object=PUBLIC_COLLECTION (as:Public). After resetting to pending,
+-- the fixed code will re-send the Follow with the correct object on next deploy.
+UPDATE relays SET status = 'pending' WHERE status = 'rejected' AND deleted_at IS NULL;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,495 @@
+{
+  "id": "8ea87930-c919-490c-9898-ffd89faf0e48",
+  "prevId": "131c07e7-1b96-4371-a6c8-c5d66556844a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor_keypairs": {
+      "name": "actor_keypairs",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_entries": {
+      "name": "feed_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "feed_entries_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boost_count": {
+          "name": "boost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feed_entries_hashtags_gin_idx": {
+          "name": "feed_entries_hashtags_gin_idx",
+          "columns": [
+            {
+              "expression": "hashtags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "feed_entries_published_at_idx": {
+          "name": "feed_entries_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_entries_bot_username_guid_unique": {
+          "name": "feed_entries_bot_username_guid_unique",
+          "columns": [
+            "bot_username",
+            "guid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_poll_status": {
+      "name": "feed_poll_status",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followers": {
+      "name": "followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "followers_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_id": {
+          "name": "follow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followers_bot_username_follower_id_unique": {
+          "name": "followers_bot_username_follower_id_unique",
+          "columns": [
+            "bot_username",
+            "follower_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.following": {
+      "name": "following",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "following_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_actor_id": {
+          "name": "target_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "following_bot_username_handle_unique": {
+          "name": "following_bot_username_handle_unique",
+          "columns": [
+            "bot_username",
+            "handle"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relays": {
+      "name": "relays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "relays_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "relay_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "relays_bot_username_url_unique": {
+          "name": "relays_bot_username_url_unique",
+          "columns": [
+            "bot_username",
+            "url"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.relay_status": {
+      "name": "relay_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776972482870,
       "tag": "0011_chilly_exiles",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1745438400000,
+      "tag": "0012_reset_rejected_relays",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -89,8 +89,8 @@
     {
       "idx": 12,
       "version": "7",
-      "when": 1745438400000,
-      "tag": "0012_reset_rejected_relays",
+      "when": 1776983700511,
+      "tag": "0012_aspiring_tiger_shark",
       "breakpoints": true
     }
   ]

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -460,7 +460,7 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
         return new Follow({
           id: followUri,
           actor: ctx.getActorUri(identifier),
-          object: new URL(relayRow.actorId),
+          object: PUBLIC_COLLECTION,
         });
       }
       return null;
@@ -845,7 +845,10 @@ export async function subscribeToRelays(
         const follow = new Follow({
           id: followId,
           actor: ctx.getActorUri(botUsername),
-          object: recipient.id,
+          // ActivityRelay expects object=PUBLIC_COLLECTION (Mastodon-style subscription),
+          // not the relay actor's own URL (which triggers the LitePub peer-relay path
+          // and gets rejected because our actor URLs don't end in /relay).
+          object: PUBLIC_COLLECTION,
         });
 
         await upsertRelay(


### PR DESCRIPTION

- ActivityRelay-based relays (relay.toot.io, relay.intahnet.co.uk) distinguish two Follow paths: **Path A** where `object=as:Public` triggers a normal Mastodon-style subscription, and **Path B** where `object=<relay-actor-url>` triggers a LitePub peer-relay mode that only accepts if the sender's actor URL ends in `/relay`
- We were accidentally using Path B, so every relay was responding with Reject (our actor URLs are `/users/{identifier}`, not `/relay`)
- Fix: change the Follow `object` field from `recipient.id` to `PUBLIC_COLLECTION` in both `subscribeToRelays()` and the Follow object dispatcher
- Migration `0012`: resets all `rejected` relay rows to `pending` so next deploy retries them with the correct format (only `minecloud.ro` is currently `accepted` and stays untouched)

