### PR TITLE
refactor: simplify header with @icco/react-common SiteHeader

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fedify/vocab": "^2.1.10",
     "@google/genai": "^1.49.0",
     "@heroicons/react": "^2.2.0",
-    "@icco/react-common": "^2026.430.1",
+    "@icco/react-common": "^2026.430.3",
     "@js-temporal/polyfill": "^0.5.1",
     "@logtape/logtape": "^2.0.2",
     "daisyui": "^5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,13 +2,8 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { Roboto, Roboto_Mono } from "next/font/google";
-import {
-  QueueListIcon,
-  TagIcon,
-  ChartBarIcon,
-  SignalIcon,
-} from "@heroicons/react/24/outline";
 import { Footer } from "@icco/react-common/Footer";
+import { SiteHeader } from "@icco/react-common/SiteHeader";
 import { WebVitals } from "@icco/react-common/WebVitals";
 import { faviconSvg } from "@/lib/og-icon";
 import "./globals.css";
@@ -60,8 +55,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     >
       <body className="min-h-screen flex flex-col bg-base-100 font-body">
         <WebVitals analyticsPath="/analytics/robot-villas" />
-        <header className="navbar bg-base-200 border-b border-base-300">
-          <div className="container mx-auto flex flex-wrap items-center gap-y-1">
+        <SiteHeader
+          showThemeToggle={false}
+          brand={
             <Link
               href="/"
               className="text-xl font-display font-bold tracking-tight hover:opacity-80 transition-opacity flex items-center gap-2"
@@ -69,30 +65,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               <span className="text-2xl">🤖</span>
               <span>{domain}</span>
             </Link>
-            <nav className="flex items-center gap-1 ml-auto">
-              <div className="tooltip tooltip-bottom" data-tip="Posts">
-                <Link href="/posts" className="btn btn-ghost btn-sm" aria-label="Posts">
-                  <QueueListIcon className="h-5 w-5" />
-                </Link>
-              </div>
-              <div className="tooltip tooltip-bottom" data-tip="Tags">
-                <Link href="/tags" className="btn btn-ghost btn-sm" aria-label="Tags">
-                  <TagIcon className="h-5 w-5" />
-                </Link>
-              </div>
-              <div className="tooltip tooltip-bottom" data-tip="Stats">
-                <Link href="/stats" className="btn btn-ghost btn-sm" aria-label="Stats">
-                  <ChartBarIcon className="h-5 w-5" />
-                </Link>
-              </div>
-              <div className="tooltip tooltip-bottom" data-tip="Status">
-                <Link href="/status" className="btn btn-ghost btn-sm" aria-label="Status">
-                  <SignalIcon className="h-5 w-5" />
-                </Link>
-              </div>
-            </nav>
-          </div>
-        </header>
+          }
+          links={[
+            { name: "Posts", href: "/posts" },
+            { name: "Tags", href: "/tags" },
+            { name: "Stats", href: "/stats" },
+            { name: "Status", href: "/status" },
+          ]}
+        />
         <main className="container mx-auto flex-1 px-4 py-8 max-w-4xl">
           {children}
         </main>

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,10 +455,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@icco/react-common@^2026.430.1":
-  version "2026.430.1"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.430.1/36885424816801ca56fce83bb5b621f08ad9c352#36885424816801ca56fce83bb5b621f08ad9c352"
-  integrity sha512-69x0XpmkQcGkZzVkjx1a5xJcUst98o1sttfdeeudoYJ1FLHI+Fytb9U2IcGvOZ7t3EpmkMYOC9FHFHEpBX4WYA==
+"@icco/react-common@^2026.430.3":
+  version "2026.430.3"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.430.3/b7829a20bbfb1ba58fb83ceaee783a136c8951b9#b7829a20bbfb1ba58fb83ceaee783a136c8951b9"
+  integrity sha512-d67dBml2zRYSMNQqLQEG6gNsemitlQ4oJu2DrcRFP7XY9R/uyIGRAPvFuU2HBOr45Nq9aXZpTgMctQK8Xvhowg==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,9 +652,9 @@
     jsbi "^4.3.0"
 
 "@logtape/logtape@^2.0.2", "@logtape/logtape@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@logtape/logtape/-/logtape-2.0.5.tgz#2069c97a5790a403c475f04d6bc294d02a1a8cb4"
-  integrity sha512-UizDkh20ZPJVOddRxG1F77WhHdlNl/sbQgoO8T534R7XvUBMAJ9En9f35u+meW2tRsNLvjz6R87Zanwf53tspQ==
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@logtape/logtape/-/logtape-2.0.6.tgz#6d545be061f2ca6b84061853f662ad05309f4d01"
+  integrity sha512-iumhZlANOLioxWajsssRz1W+bo26xmex/pFiSweIRegChYJmxGZ8ZD/UQZUSKgXJktl4wMoaWDoJ/3uHaPi7jw==
 
 "@multiformats/base-x@^4.0.1":
   version "4.0.1"


### PR DESCRIPTION
Replaces the custom navbar with `SiteHeader` from `@icco/react-common@^2026.430.3`:

- Wordmark (`🤖 + domain`) goes through the new `brand` slot, preserving the home link.
- Section nav (Posts/Tags/Stats/Status) goes through `links`. Loses the icon+tooltip rendering in favor of plain text links, matching the personal sites.
- Theme toggle disabled (`showThemeToggle={false}`) since the site is hardcoded to `data-theme="dim"` with no ThemeProvider.

Footer was already migrated; this finishes the chrome cleanup.