### PR TITLE
fix(header): restore icon nav and fix mobile overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fedify/vocab": "^2.1.10",
     "@google/genai": "^1.49.0",
     "@heroicons/react": "^2.2.0",
-    "@icco/react-common": "^2026.430.3",
+    "@icco/react-common": "^2026.510.2",
     "@js-temporal/polyfill": "^0.5.1",
     "@logtape/logtape": "^2.0.2",
     "daisyui": "^5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,12 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { Roboto, Roboto_Mono } from "next/font/google";
+import {
+  ChartBarIcon,
+  QueueListIcon,
+  SignalIcon,
+  TagIcon,
+} from "@heroicons/react/24/outline";
 import { Footer } from "@icco/react-common/Footer";
 import { SiteHeader } from "@icco/react-common/SiteHeader";
 import { WebVitals } from "@icco/react-common/WebVitals";
@@ -67,10 +73,26 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             </Link>
           }
           links={[
-            { name: "Posts", href: "/posts" },
-            { name: "Tags", href: "/tags" },
-            { name: "Stats", href: "/stats" },
-            { name: "Status", href: "/status" },
+            {
+              name: "Posts",
+              href: "/posts",
+              icon: <QueueListIcon className="h-5 w-5" />,
+            },
+            {
+              name: "Tags",
+              href: "/tags",
+              icon: <TagIcon className="h-5 w-5" />,
+            },
+            {
+              name: "Stats",
+              href: "/stats",
+              icon: <ChartBarIcon className="h-5 w-5" />,
+            },
+            {
+              name: "Status",
+              href: "/status",
+              icon: <SignalIcon className="h-5 w-5" />,
+            },
           ]}
         />
         <main className="container mx-auto flex-1 px-4 py-8 max-w-4xl">

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,10 +455,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@icco/react-common@^2026.510.1":
-  version "2026.510.2"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.510.2/148b54b2cb740bc174ba2550796c8cfa82d64a0d#148b54b2cb740bc174ba2550796c8cfa82d64a0d"
-  integrity sha512-U5rihytjY3+lGKV3kbrVlT+buSQNc6gxSQIQ+McR7icb5hiXJmfwNeaSor7wEkv4SdKe2vGLcYlWoBwLvCYAHw==
+"@icco/react-common@^2026.510.2":
+  version "2026.10510.1"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.10510.1/bfa79ee2a6aef3216007a61e883a82bfe7cf30a7#bfa79ee2a6aef3216007a61e883a82bfe7cf30a7"
+  integrity sha512-I/LER85TnMCxgNhxW3imVHyNmtoNrH6ahsBBKIvyzXrCdWAVleb1mADyT9RXc0QcN6mnelvuHgs9eFESThpiZg==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,13 +324,13 @@
   integrity sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==
 
 "@fedify/fedify@^2.1.10":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-2.2.0.tgz#896c597389d2c391d9e88769ba2a16c32ead6247"
-  integrity sha512-pJ9tid3uvao3yD+2m1gxZHnM4XpQLCFQ3mvJO6GAtBTLlE3PkdWttCTdXF7U5QQlh8NeT6HMe2MLJa2F3RzgQg==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/fedify/-/fedify-2.2.1.tgz#ee193f80d41f004261e0ec4757439bd1f286bbeb"
+  integrity sha512-OIxa7+Kp6KDpz8v6bgo67Zg8fWRNdyNbOx21WrJbPhh6RaSl7SkVm1GAQ2ehIS318ipoFUD00DvM6sKbcR+DYg==
   dependencies:
-    "@fedify/vocab" "2.2.0"
-    "@fedify/vocab-runtime" "2.2.0"
-    "@fedify/webfinger" "2.2.0"
+    "@fedify/vocab" "2.2.1"
+    "@fedify/vocab-runtime" "2.2.1"
+    "@fedify/webfinger" "2.2.1"
     "@js-temporal/polyfill" "^0.5.1"
     "@logtape/logtape" "^2.0.5"
     "@opentelemetry/api" "^1.9.0"
@@ -347,22 +347,22 @@
     urlpattern-polyfill "^10.1.0"
 
 "@fedify/next@^2.1.10":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/next/-/next-2.2.0.tgz#3ee18f52a971b4f4cbbb1885829ec7646d19be64"
-  integrity sha512-jWejVF/j6jr8Ks5tYXYr6x23ogX9HLyuqhxk1s4EU5LJQtoxbrNs407OgM/6jRsUqTX6L4NdDSWePAJlB6l1Xw==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/next/-/next-2.2.1.tgz#90e09c0200b23d7f799af92366607a30ffac4dfd"
+  integrity sha512-2rRLPujeMDvYpJ0sJx5kSj4qwK1oD5MZE0nXVUEG2Gkin+P2bdWvbLN8k5vFBrJxeINtJAxnGHlIw1c8yuGINQ==
 
 "@fedify/postgres@^2.1.10":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/postgres/-/postgres-2.2.0.tgz#aee29a8eb8e99644daa944a94733c3741d4109a4"
-  integrity sha512-WB4m+XvQMBLyMNL7o8H/KX0MwkRM3fpd1xD0zDxiziCwJYRDss7E5TUaBnBF/uqzEq5H9cLsfV2Jxls60MNzfA==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/postgres/-/postgres-2.2.1.tgz#14a8c9301ec7fe58c51fcf35076f8739217eec19"
+  integrity sha512-rnxI2IQjyzqoMli4rCQqcuXC9nE1GQkz8FRVr2itAY7ENA3Q38fVhdG+nlqWr6Yi40mkquQzPy/RY6q27w7MkQ==
   dependencies:
     "@js-temporal/polyfill" "^0.5.1"
     "@logtape/logtape" "^2.0.5"
 
-"@fedify/vocab-runtime@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/vocab-runtime/-/vocab-runtime-2.2.0.tgz#723b7ca500219faec81d4bbc1a90e0b3354fc93a"
-  integrity sha512-yHUBcJZ4HPQzexqtI2SZBBinb1DOpJ5w6gnrnSMOKnHhnySEdyEv9BX42jPyf1Y84Fer3fLOILPA7e0q9U4NbQ==
+"@fedify/vocab-runtime@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/vocab-runtime/-/vocab-runtime-2.2.1.tgz#ad4f7786f491d861111bafd2cf4052bdc1af9987"
+  integrity sha512-NRnlhUv2mmVGNMrjhmTUMN1gZaDax8KmBkUHV3U5PMDSA2aSGQ/iWCruoV4TeaCAI1nX1AW0kAH8Q9Uwkb6f8Q==
   dependencies:
     "@logtape/logtape" "^2.0.5"
     "@multiformats/base-x" "^4.0.1"
@@ -372,24 +372,24 @@
     jsonld "^9.0.0"
     pkijs "^3.3.3"
 
-"@fedify/vocab-tools@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/vocab-tools/-/vocab-tools-2.2.0.tgz#899f39a4d4459f48da6239d4ac60794aa7e2a199"
-  integrity sha512-afIUibecPo+AiCuEJ54B/6LBhb7lEXMSeelY7hTeIET0uuJyKiwMMwCIelGzpLYP9TxjfketHrYtKajMtALC6A==
+"@fedify/vocab-tools@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/vocab-tools/-/vocab-tools-2.2.1.tgz#174bff147086b2ae6a4df6543c94f819c962c11c"
+  integrity sha512-b8Gu/clgudHjSSWEVrzm3N85xlAk23keNAxLPL6uQp+oybtG7ZvBXyUMOwFvrQLKtAmcPvRh0XXVETMN2hWv2g==
   dependencies:
     "@cfworker/json-schema" "^4.1.1"
     byte-encodings "^1.0.11"
     es-toolkit "^1.39.10"
     yaml "^2.8.1"
 
-"@fedify/vocab@2.2.0", "@fedify/vocab@^2.1.10":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/vocab/-/vocab-2.2.0.tgz#22ef74007cf44e6a9644a75b542e847b8caf2071"
-  integrity sha512-b0g0EAz8DoW8L+Y6BV6qywHPJpkzKA9iy4mwFMQvvVUVVj8DF2Kv9jaFm7AUbvCdjRpOjru5uGRBPxWY4bkXGQ==
+"@fedify/vocab@2.2.1", "@fedify/vocab@^2.1.10":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/vocab/-/vocab-2.2.1.tgz#eed3894192693d7396e00ef02cae2c88d58ae135"
+  integrity sha512-sYVnwJLUYEiG6AuxR7Q+eYA3c+PzcZSDGxjmkFnMQ4mO1IU6G9Od85b66buGIV29g1+mgTYJLkBvNiLEOqBbaA==
   dependencies:
-    "@fedify/vocab-runtime" "2.2.0"
-    "@fedify/vocab-tools" "2.2.0"
-    "@fedify/webfinger" "2.2.0"
+    "@fedify/vocab-runtime" "2.2.1"
+    "@fedify/vocab-tools" "2.2.1"
+    "@fedify/webfinger" "2.2.1"
     "@js-temporal/polyfill" "^0.5.1"
     "@logtape/logtape" "^2.0.5"
     "@multiformats/base-x" "^4.0.1"
@@ -399,12 +399,12 @@
     jsonld "^9.0.0"
     pkijs "^3.3.3"
 
-"@fedify/webfinger@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@fedify/webfinger/-/webfinger-2.2.0.tgz#7bdbdf4cb77ef2fbd2e7630212c425b945649563"
-  integrity sha512-F5WCXTaCcdZ6zN4UbgwjOlDCWRL8SwHz+v3ge0uggze8OxihDy2XQEIMynOAy6mXtVauLiCHuNLPlnhIniTjBA==
+"@fedify/webfinger@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@fedify/webfinger/-/webfinger-2.2.1.tgz#638e541b73cdedcee673a979a407a96b3a2599e0"
+  integrity sha512-gRGgjCLgfvovLstTAa7U4d170SsQQSb0pIPCyE7hMRvzdgU+uIPwbtgm5Btbe/ZognzCN2Q6ELx+tAsuQGbY5g==
   dependencies:
-    "@fedify/vocab-runtime" "2.2.0"
+    "@fedify/vocab-runtime" "2.2.1"
     "@logtape/logtape" "^2.0.5"
     "@opentelemetry/api" "^1.9.0"
     es-toolkit "1.43.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,10 +455,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@icco/react-common@^2026.430.3":
-  version "2026.430.3"
-  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.430.3/b7829a20bbfb1ba58fb83ceaee783a136c8951b9#b7829a20bbfb1ba58fb83ceaee783a136c8951b9"
-  integrity sha512-d67dBml2zRYSMNQqLQEG6gNsemitlQ4oJu2DrcRFP7XY9R/uyIGRAPvFuU2HBOr45Nq9aXZpTgMctQK8Xvhowg==
+"@icco/react-common@^2026.510.1":
+  version "2026.510.2"
+  resolved "https://npm.pkg.github.com/download/@icco/react-common/2026.510.2/148b54b2cb740bc174ba2550796c8cfa82d64a0d#148b54b2cb740bc174ba2550796c8cfa82d64a0d"
+  integrity sha512-U5rihytjY3+lGKV3kbrVlT+buSQNc6gxSQIQ+McR7icb5hiXJmfwNeaSor7wEkv4SdKe2vGLcYlWoBwLvCYAHw==
   dependencies:
     "@wrksz/themes" "^0.9.0"
     vivus "^0.4.6"


### PR DESCRIPTION
## Summary

- Bumps `@icco/react-common` to `^2026.510.2`, which adds an `icon` prop to `NavLink` and collapses labels to icon-only below the `md` breakpoint (icco/react-common#106).
- Restores the four Heroicons (`QueueListIcon`, `TagIcon`, `ChartBarIcon`, `SignalIcon`) that were dropped when the site migrated to the shared `SiteHeader` in #95, fixing the mobile overflow that was the motivation for this work.
