### PR TITLE
fix: emit JSON-formatted logs via logtape jsonLinesFormatter

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,9 +1,13 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { configure, getConsoleSink } from "@logtape/logtape";
+import {
+  configure,
+  getConsoleSink,
+  jsonLinesFormatter,
+} from "@logtape/logtape";
 
 export async function setupLogging(): Promise<void> {
   await configure({
-    sinks: { console: getConsoleSink() },
+    sinks: { console: getConsoleSink({ formatter: jsonLinesFormatter }) },
     loggers: [
       { category: "robot-villas", sinks: ["console"], lowestLevel: "debug" },
       { category: ["fedify", "federation", "outbox"], sinks: ["console"], lowestLevel: "debug" },


### PR DESCRIPTION
robot-villas was logging via logtape's default human-readable formatter.