### PR TITLE
fix: remove hardcoded token from .npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - uses: mikefarah/yq@master
-      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: pnpm install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm lint
       - run: pnpm fmt:yaml
       - run: pnpm typecheck
@@ -43,8 +44,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: pnpm install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm validate-feeds
   test:
     runs-on: ubuntu-latest
@@ -71,7 +73,8 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: pnpm install --frozen-lockfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm build
       - run: pnpm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 @icco:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=ghu_NjMxRgwQ3ALiFaOvAsjSmCwdS3EDHo1tEUWL
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN npm install -g pnpm@11.2.2
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 RUN --mount=type=secret,id=npm_token \
-    echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/npm_token)" >> .npmrc && \
-    pnpm install --frozen-lockfile && \
-    rm -f .npmrc
+    GITHUB_TOKEN=$(cat /run/secrets/npm_token) \
+    pnpm install --frozen-lockfile
 
 COPY . .
 


### PR DESCRIPTION
The tracked .npmrc had a hardcoded (now expired) ghu_ token. Replaced with `${GITHUB_TOKEN}` matching lifeline: CI sets it via env on install steps, the Dockerfile exports it from the existing npm_token build secret. Verified locally that install resolves @icco/react-common with the env var set.