### PR TITLE
perf: poll bot feeds with bounded concurrency instead of fully sequential

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -59,11 +59,9 @@ export async function register() {
   });
 
   const { startPoller } = await import("@/lib/poller");
-  const pollIntervalMs = parseInt(
-    process.env.POLL_INTERVAL_MS || "300000",
-    10,
-  );
-  const pollConcurrency = parseInt(process.env.POLL_CONCURRENCY || "10", 10);
+  const { parsePositiveInt } = await import("@/lib/env");
+  const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 300_000);
+  const pollConcurrency = parsePositiveInt(process.env.POLL_CONCURRENCY, 10);
 
   startPoller({
     config,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -63,12 +63,14 @@ export async function register() {
     process.env.POLL_INTERVAL_MS || "300000",
     10,
   );
+  const pollConcurrency = parseInt(process.env.POLL_CONCURRENCY || "10", 10);
 
   startPoller({
     config,
     db,
     domain,
     intervalMs: pollIntervalMs,
+    concurrency: pollConcurrency,
     getContext: () => federation.createContext(new URL(`https://${domain}`)),
   });
 

--- a/src/lib/__tests__/concurrency.test.ts
+++ b/src/lib/__tests__/concurrency.test.ts
@@ -70,4 +70,32 @@ describe("mapWithConcurrency", () => {
       }),
     ).rejects.toThrow("boom");
   });
+
+  it("still processes every item when limit is NaN instead of silently skipping all of them", async () => {
+    const items = [1, 2, 3, 4];
+    const seen: number[] = [];
+    const results = await mapWithConcurrency(items, Number.NaN, async (i) => {
+      seen.push(i);
+      return i;
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual(items);
+    expect(results).toEqual(items);
+  });
+
+  it("falls back to sequential processing when limit is zero or negative", async () => {
+    const items = [1, 2, 3];
+    const seen: number[] = [];
+    await mapWithConcurrency(items, 0, async (i) => {
+      seen.push(i);
+      return i;
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual(items);
+
+    seen.length = 0;
+    await mapWithConcurrency(items, -5, async (i) => {
+      seen.push(i);
+      return i;
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual(items);
+  });
 });

--- a/src/lib/__tests__/concurrency.test.ts
+++ b/src/lib/__tests__/concurrency.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { mapWithConcurrency } from "../concurrency";
+
+describe("mapWithConcurrency", () => {
+  it("returns results in input order regardless of completion order", async () => {
+    const delays = [30, 10, 20, 0];
+    const results = await mapWithConcurrency(delays, 4, async (delay, i) => {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return i;
+    });
+    expect(results).toEqual([0, 1, 2, 3]);
+  });
+
+  it("never runs more than `limit` calls concurrently", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    await mapWithConcurrency(items, 3, async (i) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return i;
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
+  it("processes every item exactly once", async () => {
+    const items = Array.from({ length: 25 }, (_, i) => i);
+    const seen: number[] = [];
+    await mapWithConcurrency(items, 4, async (i) => {
+      seen.push(i);
+      return i * 2;
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual(items);
+  });
+
+  it("handles an empty item list without invoking fn", async () => {
+    let calls = 0;
+    const results = await mapWithConcurrency([], 5, async () => {
+      calls++;
+      return null;
+    });
+    expect(results).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  it("clamps effective concurrency to the number of items", async () => {
+    let active = 0;
+    let maxActive = 0;
+    await mapWithConcurrency([1, 2], 10, async (i) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return i;
+    });
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it("propagates a thrown error from fn", async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (i) => {
+        if (i === 2) {
+          throw new Error("boom");
+        }
+        return i;
+      }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/lib/__tests__/env.test.ts
+++ b/src/lib/__tests__/env.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parsePositiveInt } from "../env";
+
+describe("parsePositiveInt", () => {
+  it("returns the fallback when the value is undefined", () => {
+    expect(parsePositiveInt(undefined, 42)).toBe(42);
+  });
+
+  it("parses a valid positive integer string", () => {
+    expect(parsePositiveInt("10", 42)).toBe(10);
+  });
+
+  it("returns the fallback for non-numeric input instead of NaN", () => {
+    expect(parsePositiveInt("abc", 42)).toBe(42);
+    expect(parsePositiveInt("", 42)).toBe(42);
+    expect(parsePositiveInt("NaN", 42)).toBe(42);
+  });
+
+  it("returns the fallback for zero or negative input", () => {
+    expect(parsePositiveInt("0", 42)).toBe(42);
+    expect(parsePositiveInt("-5", 42)).toBe(42);
+  });
+
+  it("returns the fallback for non-finite input", () => {
+    expect(parsePositiveInt("Infinity", 42)).toBe(42);
+  });
+
+  it("truncates a fractional string via parseInt semantics", () => {
+    expect(parsePositiveInt("3.9", 42)).toBe(3);
+  });
+
+  it("accepts a valid positive number directly", () => {
+    expect(parsePositiveInt(10, 42)).toBe(10);
+  });
+
+  it("truncates a fractional number", () => {
+    expect(parsePositiveInt(3.9, 42)).toBe(3);
+  });
+
+  it("returns the fallback for NaN, zero, negative, or non-finite numbers", () => {
+    expect(parsePositiveInt(NaN, 42)).toBe(42);
+    expect(parsePositiveInt(0, 42)).toBe(42);
+    expect(parsePositiveInt(-5, 42)).toBe(42);
+    expect(parsePositiveInt(Infinity, 42)).toBe(42);
+  });
+});

--- a/src/lib/__tests__/poller.test.ts
+++ b/src/lib/__tests__/poller.test.ts
@@ -116,4 +116,24 @@ describe("startPoller concurrency", () => {
 
     poller.stop();
   });
+
+  it("falls back to the default concurrency instead of polling zero bots when given NaN", async () => {
+    const botCount = 3;
+    mockFetchFeed.mockResolvedValue({ entries: [], httpStatus: 200, errorMessage: null });
+
+    const poller = startPoller({
+      config: makeConfig(botCount),
+      db: {} as never,
+      domain: "robot.villas",
+      intervalMs: 10_000_000,
+      concurrency: Number.parseInt("not-a-number", 10),
+      getContext: () => ({}) as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFetchFeed).toHaveBeenCalledTimes(botCount);
+    });
+
+    poller.stop();
+  });
 });

--- a/src/lib/__tests__/poller.test.ts
+++ b/src/lib/__tests__/poller.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../rss", () => ({
+  fetchFeedWithHttpResult: vi.fn(),
+}));
+
+vi.mock("../publisher", () => ({
+  publishNewEntries: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  upsertFeedPollStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { fetchFeedWithHttpResult } from "../rss";
+import { publishNewEntries } from "../publisher";
+import { startPoller } from "../poller";
+import type { FeedsConfig } from "../config";
+
+const mockFetchFeed = vi.mocked(fetchFeedWithHttpResult);
+const mockPublishNewEntries = vi.mocked(publishNewEntries);
+
+function makeConfig(botCount: number): FeedsConfig {
+  const bots: FeedsConfig["bots"] = {};
+  for (let i = 0; i < botCount; i++) {
+    bots[`bot${i}`] = {
+      feed_url: `https://example.com/feed${i}.xml`,
+      display_name: `Bot ${i}`,
+      summary: "A test bot",
+    };
+  }
+  return { bots, follows: [], relays: [] };
+}
+
+describe("startPoller concurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPublishNewEntries.mockResolvedValue({ published: 0, skipped: 0 });
+  });
+
+  it("polls all configured bots", async () => {
+    const botCount = 6;
+    mockFetchFeed.mockResolvedValue({ entries: [], httpStatus: 200, errorMessage: null });
+
+    const poller = startPoller({
+      config: makeConfig(botCount),
+      db: {} as never,
+      domain: "robot.villas",
+      intervalMs: 10_000_000,
+      concurrency: 2,
+      getContext: () => ({}) as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFetchFeed).toHaveBeenCalledTimes(botCount);
+    });
+
+    poller.stop();
+  });
+
+  it("never has more than `concurrency` feed fetches in flight at once", async () => {
+    const botCount = 8;
+    const concurrency = 2;
+    let active = 0;
+    let maxActive = 0;
+
+    mockFetchFeed.mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      active--;
+      return { entries: [], httpStatus: 200, errorMessage: null };
+    });
+
+    const poller = startPoller({
+      config: makeConfig(botCount),
+      db: {} as never,
+      domain: "robot.villas",
+      intervalMs: 10_000_000,
+      concurrency,
+      getContext: () => ({}) as never,
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(mockFetchFeed).toHaveBeenCalledTimes(botCount);
+      },
+      { timeout: 5000 },
+    );
+
+    poller.stop();
+    expect(maxActive).toBeLessThanOrEqual(concurrency);
+  });
+
+  it("continues polling remaining bots when one bot's fetch throws", async () => {
+    const botCount = 4;
+    mockFetchFeed.mockImplementation(async (feedUrl: string) => {
+      if (feedUrl.includes("feed1")) {
+        throw new Error("network error");
+      }
+      return { entries: [], httpStatus: 200, errorMessage: null };
+    });
+
+    const poller = startPoller({
+      config: makeConfig(botCount),
+      db: {} as never,
+      domain: "robot.villas",
+      intervalMs: 10_000_000,
+      concurrency: 2,
+      getContext: () => ({}) as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFetchFeed).toHaveBeenCalledTimes(botCount);
+    });
+
+    poller.stop();
+  });
+});

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -14,7 +14,11 @@ export async function mapWithConcurrency<T, R>(
     return results;
   }
   let nextIndex = 0;
-  const workerCount = Math.max(1, Math.min(limit, items.length));
+  // Guard against a non-finite/non-positive limit (e.g. NaN from a bad env
+  // var) collapsing Array.from({length}) to zero workers, which would
+  // silently skip every item instead of falling back to sequential.
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? limit : 1;
+  const workerCount = Math.max(1, Math.min(safeLimit, items.length));
 
   async function worker(): Promise<void> {
     while (nextIndex < items.length) {

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,28 @@
+/**
+ * Runs `fn` over `items` with at most `limit` calls in flight at once,
+ * preserving input order in the returned array. Used to bound how many
+ * feeds/requests run concurrently without waiting for a fully sequential
+ * loop or firing everything at once.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  if (items.length === 0) {
+    return results;
+  }
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,20 @@
+/**
+ * Parses a value as a positive integer, falling back to `fallback` when it's
+ * missing, non-numeric, non-finite, or not positive. Guards config knobs
+ * (poll interval/concurrency, etc.) against a malformed env var or caller
+ * input silently turning into `NaN` and breaking downstream arithmetic (e.g.
+ * a `NaN` concurrency limit collapsing a worker pool to zero workers).
+ */
+export function parsePositiveInt(
+  value: string | number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = typeof value === "number" ? Math.trunc(value) : Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -1,11 +1,15 @@
 import type { Context } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
-import type { FeedsConfig } from "./config";
+import type { BotConfig, FeedsConfig } from "./config";
+import { mapWithConcurrency } from "./concurrency";
 import { upsertFeedPollStatus, type Db } from "./db";
 import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+/** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
+ * poll cycle run far longer than intervalMs when polled fully sequentially. */
+const DEFAULT_CONCURRENCY = 10;
 const logger = getLogger(["robot-villas", "poller"]);
 
 export interface PollerOptions {
@@ -13,56 +17,64 @@ export interface PollerOptions {
   db: Db;
   domain: string;
   intervalMs?: number;
+  concurrency?: number;
   getContext: () => Context<void>;
 }
 
 export function startPoller(opts: PollerOptions): { stop: () => void } {
   const { config, db, domain, getContext } = opts;
   const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
   const botNames = Object.keys(config.bots);
 
   let stopped = false;
 
   logger.info(
-    "Starting: {botCount} bot(s) [{botNames}], interval {intervalMs}ms",
-    { botCount: botNames.length, botNames: botNames.join(", "), intervalMs },
+    "Starting: {botCount} bot(s) [{botNames}], interval {intervalMs}ms, concurrency {concurrency}",
+    { botCount: botNames.length, botNames: botNames.join(", "), intervalMs, concurrency },
   );
+
+  async function pollBot(ctx: Context<void>, username: string, bot: BotConfig): Promise<void> {
+    const checkedAt = new Date();
+    try {
+      const fetchResult = await fetchFeedWithHttpResult(bot.feed_url);
+      await upsertFeedPollStatus(
+        db,
+        username,
+        checkedAt,
+        fetchResult.httpStatus,
+        fetchResult.errorMessage,
+      );
+      if (fetchResult.errorMessage) {
+        logger.warn("Feed poll failed for {username}: {message}", {
+          username,
+          message: fetchResult.errorMessage,
+        });
+        return;
+      }
+      const result = await publishNewEntries(ctx, db, username, domain, fetchResult.entries, bot);
+      logger.info(
+        "Fetched {entryCount} entries for {username}, published {published}, skipped {skipped}",
+        {
+          username,
+          entryCount: fetchResult.entries.length,
+          published: result.published,
+          skipped: result.skipped,
+        },
+      );
+    } catch (err) {
+      logger.error("Error polling {username}: {error}", { username, error: err });
+    }
+  }
 
   async function poll(): Promise<void> {
     logger.info("Poll cycle starting");
     const ctx = getContext();
-    for (const [username, bot] of Object.entries(config.bots)) {
-      const checkedAt = new Date();
-      try {
-        const fetchResult = await fetchFeedWithHttpResult(bot.feed_url);
-        await upsertFeedPollStatus(
-          db,
-          username,
-          checkedAt,
-          fetchResult.httpStatus,
-          fetchResult.errorMessage,
-        );
-        if (fetchResult.errorMessage) {
-          logger.warn("Feed poll failed for {username}: {message}", {
-            username,
-            message: fetchResult.errorMessage,
-          });
-          continue;
-        }
-        const result = await publishNewEntries(ctx, db, username, domain, fetchResult.entries, bot);
-        logger.info(
-          "Fetched {entryCount} entries for {username}, published {published}, skipped {skipped}",
-          {
-            username,
-            entryCount: fetchResult.entries.length,
-            published: result.published,
-            skipped: result.skipped,
-          },
-        );
-      } catch (err) {
-        logger.error("Error polling {username}: {error}", { username, error: err });
-      }
-    }
+    await mapWithConcurrency(
+      Object.entries(config.bots),
+      concurrency,
+      ([username, bot]) => pollBot(ctx, username, bot),
+    );
     logger.info("Poll cycle complete");
   }
 

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -3,6 +3,7 @@ import { getLogger } from "@logtape/logtape";
 import type { BotConfig, FeedsConfig } from "./config";
 import { mapWithConcurrency } from "./concurrency";
 import { upsertFeedPollStatus, type Db } from "./db";
+import { parsePositiveInt } from "./env";
 import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
@@ -23,8 +24,8 @@ export interface PollerOptions {
 
 export function startPoller(opts: PollerOptions): { stop: () => void } {
   const { config, db, domain, getContext } = opts;
-  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
-  const concurrency = opts.concurrency ?? DEFAULT_CONCURRENCY;
+  const intervalMs = parsePositiveInt(opts.intervalMs, DEFAULT_INTERVAL_MS);
+  const concurrency = parsePositiveInt(opts.concurrency, DEFAULT_CONCURRENCY);
   const botNames = Object.keys(config.bots);
 
   let stopped = false;


### PR DESCRIPTION
## Summary
- `startPoller`'s `poll()` fetched and published every configured bot's RSS feed one at a time in a `for...of` loop. `feeds.yml` currently configures 100 bots; each fetch has up to a 10s timeout (`FEED_FETCH_TIMEOUT_MS`), and publishing new entries can trigger a Gemini API call per entry. Polled fully sequentially, a single cycle can take far longer than the default 5-minute `POLL_INTERVAL_MS`, so cycles lag behind schedule or effectively run back-to-back instead of every 5 minutes.
- Added a small `mapWithConcurrency()` worker-pool helper (`src/lib/concurrency.ts`) and used it in `poller.ts` to poll bots with bounded parallelism (default 10 concurrent, configurable via the new `POLL_CONCURRENCY` env var, following the existing `POLL_INTERVAL_MS` pattern).
- Per-bot behavior is unchanged: each bot's fetch/publish is still wrapped in its own try/catch, so one bot's failure doesn't affect the others; this PR only changes how many run at once.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (`vitest run`) — 89/89 passing, including new coverage:
  - `mapWithConcurrency`: preserves input order, never exceeds the concurrency limit, processes every item exactly once, handles empty input, clamps to item count, propagates thrown errors.
  - `startPoller`: polls every configured bot, never has more in-flight feed fetches than the configured concurrency, and keeps polling remaining bots when one bot's fetch throws.