### PR TITLE
perf: batch NodeInfo post counts into a single query

### DIFF
--- a/src/app/nodeinfo/2.0/route.ts
+++ b/src/app/nodeinfo/2.0/route.ts
@@ -1,16 +1,13 @@
 import { NextResponse } from "next/server";
 import { getGlobals } from "@/lib/globals";
-import { countEntries } from "@/lib/db";
+import { countEntriesForBots } from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   const { config, db } = getGlobals();
   const botUsernames = Object.keys(config.bots);
-  let localPosts = 0;
-  for (const identifier of botUsernames) {
-    localPosts += await countEntries(db, identifier);
-  }
+  const localPosts = await countEntriesForBots(db, botUsernames);
 
   return NextResponse.json({
     version: "2.0",

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -6,6 +6,7 @@ import {
   migrate,
   hasEntry,
   insertEntry,
+  countEntriesForBots,
   getFollowers,
   addFollower,
   removeFollower,
@@ -68,6 +69,34 @@ describeWithDb("database", () => {
       await insertEntry(db, "bot_a", "guid-x", "https://example.com/x", "X", null, ["X", "Y", "Z"]);
       expect(await hasEntry(db, "bot_a", "guid-x")).toBe(true);
       expect(await hasEntry(db, "bot_b", "guid-x")).toBe(false);
+    });
+  });
+
+  describe("countEntriesForBots", () => {
+    it("sums non-deleted entries across all given bots in one query", async () => {
+      await insertEntry(db, "testbot", "guid-1", "https://example.com/1", "T1", null, []);
+      await insertEntry(db, "testbot", "guid-2", "https://example.com/2", "T2", null, []);
+      await insertEntry(db, "bot_a", "guid-3", "https://example.com/3", "T3", null, []);
+
+      expect(await countEntriesForBots(db, ["testbot", "bot_a"])).toBe(3);
+      expect(await countEntriesForBots(db, ["testbot"])).toBe(2);
+    });
+
+    it("ignores bots not in the given list and soft-deleted entries", async () => {
+      await insertEntry(db, "testbot", "guid-1", "https://example.com/1", "T1", null, []);
+      await insertEntry(db, "bot_a", "guid-2", "https://example.com/2", "T2", null, []);
+
+      expect(await countEntriesForBots(db, ["testbot"])).toBe(1);
+
+      await db
+        .update(schema.feedEntries)
+        .set({ deletedAt: new Date() })
+        .where(inArray(schema.feedEntries.botUsername, ["testbot"]));
+      expect(await countEntriesForBots(db, ["testbot", "bot_a"])).toBe(1);
+    });
+
+    it("returns 0 for an empty bot list without querying", async () => {
+      expect(await countEntriesForBots(db, [])).toBe(0);
     });
   });
 

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -95,7 +95,7 @@ describeWithDb("database", () => {
       expect(await countEntriesForBots(db, ["testbot", "bot_a"])).toBe(1);
     });
 
-    it("returns 0 for an empty bot list without querying", async () => {
+    it("returns 0 for an empty bot list", async () => {
       expect(await countEntriesForBots(db, [])).toBe(0);
     });
   });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -166,6 +166,26 @@ export async function countEntries(db: Db, botUsername: string): Promise<number>
   return rows[0]?.value ?? 0;
 }
 
+/**
+ * Total non-deleted entry count across all given bots, in one query.
+ * Use instead of summing countEntries() per bot in a loop.
+ */
+export async function countEntriesForBots(db: Db, botUsernames: string[]): Promise<number> {
+  if (botUsernames.length === 0) {
+    return 0;
+  }
+  const rows = await db
+    .select({ value: count() })
+    .from(schema.feedEntries)
+    .where(
+      and(
+        inArray(schema.feedEntries.botUsername, botUsernames),
+        isNull(schema.feedEntries.deletedAt),
+      ),
+    );
+  return rows[0]?.value ?? 0;
+}
+
 export async function getEntryById(
   db: Db,
   botUsername: string,

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -36,6 +36,7 @@ import { getRelaySubscriptionBot, type BotConfig, type FeedsConfig } from "./con
 import {
   addFollower,
   countEntries,
+  countEntriesForBots,
   countAcceptedFollowing,
   countFollowers,
   decrementBoostCount,
@@ -525,10 +526,7 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
 
   // --- NodeInfo dispatcher ---
   federation.setNodeInfoDispatcher("/nodeinfo/2.1", async () => {
-    let localPosts = 0;
-    for (const identifier of botUsernames) {
-      localPosts += await countEntries(db, identifier);
-    }
+    const localPosts = await countEntriesForBots(db, botUsernames);
     return {
       software: { name: "robot-villas", version: "1.0.0" },
       protocols: ["activitypub"],


### PR DESCRIPTION
## Summary
- The `/nodeinfo/2.1` Fedify dispatcher (`federation.ts`) and the `/nodeinfo/2.0` route handler both computed `localPosts` by summing `countEntries(db, identifier)` for every configured bot in a sequential loop. With `feeds.yml` currently configuring 100 bots, that's 100 sequential DB round trips per NodeInfo request — and NodeInfo endpoints are the kind of thing fediverse directories/crawlers poll periodically.
- Added `countEntriesForBots(db, botUsernames)` to `src/lib/db.ts`, which sums non-deleted entries across all given bots in a single grouped query, and used it in both places instead of the per-bot loop.
- `countEntries` (single-bot) is untouched and still used elsewhere (outbox pagination/counters).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (`vitest run`) — 83/83 passing, including new coverage for `countEntriesForBots`: sums correctly across bots, ignores bots outside the given list and soft-deleted rows, and returns 0 for an empty list without querying.