### PR TITLE
fix: guard against NaN offset from invalid ?page= query param

### DIFF
--- a/src/app/bot/[username]/page.tsx
+++ b/src/app/bot/[username]/page.tsx
@@ -10,6 +10,7 @@ import {
   countFollowers,
   getEntriesPage,
 } from "@/lib/db";
+import { parsePageParam } from "@/lib/pagination";
 import { FollowButton } from "./mastodon-widgets";
 
 const PROFILE_PAGE_SIZE = 40;
@@ -49,8 +50,8 @@ export default async function BotProfilePage({ params, searchParams }: Props) {
   }
 
   const { page: pageParam } = await searchParams;
-  const page = parseInt(pageParam || "0", 10);
-  const offset = Math.max(0, page) * PROFILE_PAGE_SIZE;
+  const page = parsePageParam(pageParam);
+  const offset = page * PROFILE_PAGE_SIZE;
   const [total, followerCount, followingCount, entries] = await Promise.all([
     countEntries(db, username),
     countFollowers(db, username),

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { PostFeed } from "@/components/feed-entries";
 import { getGlobals } from "@/lib/globals";
 import { getAllEntries, countAllEntries } from "@/lib/db";
+import { parsePageParam } from "@/lib/pagination";
 
 const PAGE_SIZE = 40;
 
@@ -24,7 +25,7 @@ export default async function PostsPage({ searchParams }: Props) {
   const { db, domain } = getGlobals();
 
   const { page: pageParam } = await searchParams;
-  const page = Math.max(0, parseInt(pageParam || "0", 10));
+  const page = parsePageParam(pageParam);
   const offset = page * PAGE_SIZE;
 
   const [total, entries] = await Promise.all([

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { PostFeed } from "@/components/feed-entries";
 import { getGlobals } from "@/lib/globals";
 import { countEntriesByTag, getEntriesByTag } from "@/lib/db";
+import { parsePageParam } from "@/lib/pagination";
 
 const PAGE_SIZE = 40;
 
@@ -31,7 +32,7 @@ export default async function TagPage({ params, searchParams }: Props) {
   const displayTag = decodeURIComponent(tag);
 
   const { page: pageParam } = await searchParams;
-  const page = Math.max(0, parseInt(pageParam || "0", 10));
+  const page = parsePageParam(pageParam);
   const offset = page * PAGE_SIZE;
 
   const [total, entries] = await Promise.all([

--- a/src/lib/__tests__/pagination.test.ts
+++ b/src/lib/__tests__/pagination.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { parsePageParam } from "../pagination";
+
+describe("parsePageParam", () => {
+  it("returns 0 when the param is missing", () => {
+    expect(parsePageParam(undefined)).toBe(0);
+  });
+
+  it("parses a valid positive integer", () => {
+    expect(parsePageParam("3")).toBe(3);
+    expect(parsePageParam("0")).toBe(0);
+  });
+
+  it("falls back to 0 for non-numeric input instead of NaN", () => {
+    expect(parsePageParam("abc")).toBe(0);
+    expect(parsePageParam("")).toBe(0);
+    expect(parsePageParam("NaN")).toBe(0);
+  });
+
+  it("falls back to 0 for negative input", () => {
+    expect(parsePageParam("-1")).toBe(0);
+    expect(parsePageParam("-100")).toBe(0);
+  });
+
+  it("falls back to 0 for non-finite input", () => {
+    expect(parsePageParam("Infinity")).toBe(0);
+  });
+
+  it("truncates a fractional string via parseInt semantics", () => {
+    expect(parsePageParam("2.9")).toBe(2);
+  });
+
+  it("parses the leading integer out of a mixed string", () => {
+    expect(parsePageParam("2abc")).toBe(2);
+  });
+});

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,13 @@
+/**
+ * Parses a `?page=` search param into a safe, non-negative page index.
+ * Missing, non-numeric (e.g. "abc"), negative, or non-finite values all
+ * fall back to 0 instead of producing NaN, which would otherwise reach
+ * drizzle's `.offset()` as `OFFSET NaN` and fail at the database.
+ */
+export function parsePageParam(pageParam: string | undefined): number {
+  const page = Number.parseInt(pageParam ?? "", 10);
+  if (!Number.isFinite(page) || page < 0) {
+    return 0;
+  }
+  return page;
+}

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,7 +1,9 @@
 /**
  * Parses a `?page=` search param into a safe, non-negative page index.
- * Missing, non-numeric (e.g. "abc"), negative, or non-finite values all
- * fall back to 0 instead of producing NaN, which would otherwise reach
+ * Uses `parseInt` semantics: a leading integer is read out of the string
+ * (so "2abc" -> 2) and fractional values truncate ("2.9" -> 2). Missing,
+ * entirely non-numeric (e.g. "abc"), negative, or non-finite values fall
+ * back to 0 instead of producing NaN, which would otherwise reach
  * drizzle's `.offset()` as `OFFSET NaN` and fail at the database.
  */
 export function parsePageParam(pageParam: string | undefined): number {


### PR DESCRIPTION
## Summary
- `posts/page.tsx`, `tags/[tag]/page.tsx`, and `bot/[username]/page.tsx` each parsed `?page=` with `parseInt()`/`Math.max()` without checking for `NaN`. A non-numeric value (e.g. `/posts?page=abc`, or any crawler/bookmark appending a malformed query param) produces `offset = NaN`, which reaches drizzle's `.offset()` and fails at the database instead of gracefully falling back to page 0.
- Added a shared `parsePageParam(pageParam)` helper in `src/lib/pagination.ts` that clamps missing, non-numeric, negative, or non-finite input to `0`, and used it in all three pages.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (`vitest run`) — 87/87 passing, including new unit tests for `parsePageParam` covering missing/valid/non-numeric/negative/non-finite/mixed input.
- [x] Manually verified against a local dev server + Postgres: `GET /posts?page=abc` returns `200` and renders the first page after this fix.