### PR TITLE
fix: unbreak CI - stale pnpm postcss override + dead profile photo

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -116,7 +116,7 @@ bots:
     feed_url: https://transactional.blog/feed.xml
     display_name: Transactional
     summary: Deep dives into database internals.
-    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://transactional.blog&size=128
+    profile_photo: https://www.google.com/s2/favicons?domain=transactional.blog&sz=128
   cloudflare:
     feed_url: https://blog.cloudflare.com/rss/
     display_name: Cloudflare Blog

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@opentelemetry/sdk-metrics': ^2.10.0
   esbuild: ^0.28.0
-  postcss: ^8.5.24
+  postcss: ^8.5.25
   sharp: ^0.35.3
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 overrides:
   '@opentelemetry/sdk-metrics': ^2.10.0
   esbuild: ^0.28.0
-  postcss: ^8.5.24
+  postcss: ^8.5.25
   sharp: ^0.35.3
 allowBuilds:
   '@google/genai': true


### PR DESCRIPTION
## Summary
This is a pre-existing break on `main` (not introduced by my other open PRs), surfaced because it fails every job that runs `pnpm install --frozen-lockfile` — which is why #117, #118, #119, and #120 all show red on `lint-and-typecheck`, `test`, `validate-feeds`, and `build-and-push-image`. `main`'s own scheduled `bump` workflow has been failing for the same reason since the security-patch commit (#116) landed.

Two independent issues:
- **Stale pnpm override**: #116 bumped `postcss` to `^8.5.25` in `package.json`, but `pnpm-workspace.yaml`'s `overrides.postcss` (and the mirrored `overrides:` block in `pnpm-lock.yaml`) were left at `^8.5.24`. `pnpm install --frozen-lockfile` treats that as a specifier mismatch and refuses to install, so CI never even reaches the actual lint/test/build/validate-feeds commands. Bumped both to `^8.5.25` — no dependency resolution changes, since `8.5.25` was already the resolved version everywhere else.
- **Dead profile photo URL**: `feeds.yml`'s `transactional` bot pointed its `profile_photo` at Google's `faviconV2` endpoint, which 404s for that domain. Swapped it for the legacy `google.com/s2/favicons` endpoint, verified to return a valid PNG for the same site — this is what `validate-feeds` was failing on.

## Test plan
- [x] `pnpm install --frozen-lockfile` — now gets past the "Lockfile is up to date, resolution step is skipped" stage (previously failed immediately with a specifier mismatch)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 80/80 passing
- [x] `pnpm lint` (eslint)
- [x] `pnpm validate-feeds` — now reports "All profile photos are reachable and have valid MIME types" (previously 1 error)
- [x] `next build` — succeeds