### PR TITLE
fix: reduce validate-feeds CI flakiness

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -116,7 +116,6 @@ bots:
     feed_url: https://transactional.blog/feed.xml
     display_name: Transactional
     summary: Deep dives into database internals.
-    profile_photo: https://www.google.com/s2/favicons?domain=transactional.blog&sz=128
   cloudflare:
     feed_url: https://blog.cloudflare.com/rss/
     display_name: Cloudflare Blog

--- a/scripts/validate-feeds.ts
+++ b/scripts/validate-feeds.ts
@@ -95,7 +95,15 @@ async function main() {
   await Promise.all(
     bots.map(async ([name, bot]) => {
       const url = bot.profile_photo!;
-      const r = await probeUrl(url);
+      let r = await probeUrl(url);
+
+      // A transient origin hiccup (e.g. a momentary error page served with
+      // 200 text/html, or a dropped connection) shouldn't fail CI outright.
+      // Retry once after a short delay before treating it as a real error.
+      if (r.kind === "wrong_mime" || r.kind === "network_error") {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        r = await probeUrl(url);
+      }
 
       if (r.kind === "blocked") {
         warnings.push(


### PR DESCRIPTION
## Summary
Two issues surfaced by CI failures on `main` right after merging the recent perf/fix PR batch (#117-#120) plus the CI-unblock fix (#121):

- **`probeUrl()` had no retry for a transient wrong-MIME/network error.** If an origin momentarily served a 200 response with the wrong content-type (e.g. an ephemeral error page) or a network blip occurred, the whole `validate-feeds` job failed outright. It already retried on 403/429/405; extended the same idea to these two cases with a single retry after a short delay.
- **`transactional`'s `profile_photo` (set in #121) pointed at Google's legacy `s2/favicons` endpoint**, which returned HTTP 404 specifically from GitHub Actions runners (verified it works fine from other networks) — looks like an IP-based restriction on that undocumented endpoint, which no retry can fix. The site itself has no PNG/JPEG/GIF/WebP asset (only a `favicon.ico`, whose `image/x-icon` MIME type Mastodon doesn't accept), so removed `profile_photo` for this bot instead of depending on a flaky third-party proxy. The app already falls back to a generic icon when `profile_photo` is absent, same as several other bots in `feeds.yml`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 116/116 passing
- [x] `pnpm validate-feeds` — "All profile photos are reachable and have valid MIME types"
- [x] `next build` succeeds