### PR TITLE
chore: add CODEOWNERS to auto-request review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Request @icco's review on every pull request.
+# Note: GitHub never requests review from a PR's own author, so this
+# applies to contributions from others (Dependabot, Copilot, outside PRs).
+* @icco

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-# Request @icco's review on every pull request.
-# Note: GitHub never requests review from a PR's own author, so this
-# applies to contributions from others (Dependabot, Copilot, outside PRs).
 * @icco


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @icco`, so every PR automatically requests your review.

Caveat: GitHub never requests a review from a PR's own author, so this only fires on PRs from others — Dependabot, Copilot, and outside contributors like #123. Your own PRs stay unassigned; there is no CODEOWNERS-based way around that.

If you also want to *block* merging until that review lands, that needs a branch protection rule with "Require review from Code Owners" — say the word and I'll add it.