### PR TITLE
fix: cdm profile_photo blocked from GitHub Actions runners

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -17,7 +17,7 @@ bots:
     feed_url: https://cdm.link/feed/
     display_name: CDM Create Digital Music
     summary: Create digital music, motion, and more.
-    profile_photo: https://cdm.link/app/uploads/2015/12/cdmlogo-200x200.png
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://cdm.link&size=128
   synthtopia:
     feed_url: https://www.synthtopia.com/feed/
     display_name: Synthtopia


### PR DESCRIPTION
## Summary
- \`validate-feeds\` has been failing on \`main\` since the #126/#127/#128 merges — \`cdm\`'s \`profile_photo\` (\`cdm.link\`'s own uploads path) serves \`text/html\` instead of PNG specifically from GitHub Actions IPs, same class of issue fixed for \`transactional\` in #122.
- Swaps to Google's favicon proxy, already used reliably by several other entries in this file.

## Test plan
- [ ] CI passes