### PR TITLE
fix: feeds icons and urls

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  truthy: disable

--- a/feeds.yml
+++ b/feeds.yml
@@ -691,7 +691,7 @@ bots:
     feed_url: https://www.publicbooks.org/feed/
     display_name: Public Books
     summary: Literature, culture, politics, criticism, and ideas from scholars and writers.
-    profile_photo: https://www.publicbooks.org/wp-content/uploads/2020/09/cropped-favicon-2-300x300.png
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://www.publicbooks.org&size=128
   paris_review:
     feed_url: https://www.theparisreview.org/blog/feed/
     display_name: The Paris Review

--- a/feeds.yml
+++ b/feeds.yml
@@ -116,6 +116,7 @@ bots:
     feed_url: https://transactional.blog/feed.xml
     display_name: Transactional
     summary: Deep dives into database internals.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://transactional.blog&size=128
   cloudflare:
     feed_url: https://blog.cloudflare.com/rss/
     display_name: Cloudflare Blog
@@ -521,130 +522,162 @@ bots:
     feed_url: https://martinfowler.com/feed.atom
     display_name: Martin Fowler
     summary: Software architecture, design, refactoring, and engineering practice.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://martinfowler.com&size=128
   pragmatic_engineer:
     feed_url: https://blog.pragmaticengineer.com/rss/
     display_name: The Pragmatic Engineer
     summary: Software engineering, technology companies, and engineering leadership.
+    profile_photo: https://storage.ghost.io/c/39/f8/39f85cc7-8637-40fc-a57c-f45754453717/content/images/size/w256h256/2024/06/The-Pragmatic-Engineer-Blog-Publication-Icon--Logo-.png
   hillel_wayne:
     feed_url: https://www.hillelwayne.com/index.xml
     display_name: Hillel Wayne
     summary: Software engineering, programming languages, formal methods, and computer science.
+    profile_photo: https://avatars.githubusercontent.com/u/2660212?s=200
   mitchell_hashimoto:
     feed_url: https://mitchellh.com/feed.xml
     display_name: Mitchell Hashimoto
     summary: Software engineering, infrastructure, developer tools, and programming.
+    profile_photo: https://mitchellh.com/static/favicons/apple-touch-icon.png
   jeff_geerling:
     feed_url: https://www.jeffgeerling.com/blog.xml
     display_name: Jeff Geerling
     summary: Linux, hardware, Raspberry Pi, homelabs, automation, and open source.
+    profile_photo: https://www.jeffgeerling.com/apple-touch-icon.png
   netflix_tech:
     feed_url: https://netflixtechblog.com/feed
     display_name: Netflix TechBlog
     summary: Engineering stories about distributed systems, infrastructure, and large-scale software.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://netflixtechblog.com&size=128
   stripe_engineering:
     feed_url: https://stripe.com/blog/feed.rss
     display_name: Stripe Engineering
     summary: Engineering, APIs, infrastructure, and building reliable financial software.
+    profile_photo: https://images.stripeassets.com/fzn2n1nzq965/4vVgZi0ZMoEzOhkcv7EVwK/8cce6fdcf2733b2ec8e99548908847ed/favicon.png?w=180&h=180
   github_engineering:
     feed_url: https://github.blog/engineering/feed/
     display_name: GitHub Engineering
     summary: Engineering stories about developer tools, infrastructure, and software development.
+    profile_photo: https://github.blog/wp-content/uploads/2019/01/cropped-github-favicon-512.png?fit=180%2C180
   synth_anatomy:
     feed_url: https://synthanatomy.com/feed
     display_name: Synth Anatomy
     summary: News and reviews about synthesizers, music technology, and electronic music.
+    profile_photo: https://synthanatomy.com/wp-content/uploads/2017/06/Synth_Anatomy_Icon_1.png
   synth_history:
     feed_url: https://www.synthhistory.com/blog-feed.xml
     display_name: Synth History
     summary: Stories about the history, people, instruments, and culture of synthesizers.
+    profile_photo: https://static.wixstatic.com/media/8c9e81_a58d513f3b184515b750539f47c5c6a1%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/8c9e81_a58d513f3b184515b750539f47c5c6a1%7Emv2.png
   gwern:
     feed_url: https://gwern.net/feed
     display_name: Gwern
     summary: Long-form research into AI, statistics, psychology, technology, and unusual corners of the internet.
+    profile_photo: https://gwern.net/static/img/logo/logo-favicon-appletouch.png
   stanislas:
     feed_url: https://stanislas.blog/feed.xml
     display_name: Stanislas
     summary: Rust, Go, DevOps, networking, home automation, terminal tools, and software tinkering.
+    profile_photo: https://stanislas.blog/apple-touch-icon.png
   adactio:
     feed_url: https://adactio.com/articles/rss
     display_name: Adactio
     summary: Web standards, web development, design, and the history and future of the web.
+    profile_photo: https://adactio.com/icon.png
   figma:
     feed_url: https://www.figma.com/blog/feed/atom.xml
     display_name: Figma Engineering
     summary: Graphics, collaboration, frontend, infrastructure, and unusual engineering problems.
+    profile_photo: https://static.figma.com/app/icon/2/touch-180.png
   sean_goedecke:
     feed_url: https://www.seangoedecke.com/rss.xml
     display_name: Sean Goedecke
     summary: Software engineering, technical leadership, architecture, and engineering organizations.
+    profile_photo: https://www.seangoedecke.com/icons/icon-512x512.png?v=ac7bb3aa286bd21c42741d9c9aa60cb7
   horizontalpitch:
     feed_url: https://www.horizontalpitch.com/feed/
     display_name: Horizontalpitch
     summary: Modular synthesis, Eurorack, electronic music, experimentation, and making music without presets.
+    profile_photo: https://www.horizontalpitch.com/wp-content/uploads/2023/10/cropped-icon512-180x180.png
   mark_mosher:
     feed_url: https://markmoshermusic.com/feed/
     display_name: Mark Mosher
     summary: Experimental electronic music, synthesis, dark ambient, cinematic music, glitch, and multimedia.
+    profile_photo: https://i0.wp.com/markmoshermusic.com/wp-content/uploads/2022/02/cropped-2da15-cropped-snapshot-06-06-2021-0917-1.png?fit=180%2C180&ssl=1
   jondent:
     feed_url: https://djjondent.blogspot.com/feeds/posts/default?alt=rss
     display_name: JonDent
     summary: Electronic music, synthesizers, DJing, production, art, travel, and culture.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://djjondent.blogspot.com&size=128
   the_marginalian:
     feed_url: https://www.themarginalian.org/feed/
     display_name: The Marginalian
     summary: Art, science, literature, philosophy, creativity, and the human experience.
+    profile_photo: https://i0.wp.com/www.themarginalian.org/wp-content/uploads/2021/10/cropped-tm_site_icon-1.png?fit=180%2C180&ssl=1
   public_domain_review:
     feed_url: https://publicdomainreview.org/rss.xml
     display_name: The Public Domain Review
     summary: Curated art, literature, history, science, and strange treasures from the public domain.
+    profile_photo: https://publicdomainreview.org/apple-icon-180x180.png
   scott_berkun:
     feed_url: https://scottberkun.com/feed/
     display_name: Scott Berkun
     summary: Design, creativity, technology, management, and how people work.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://scottberkun.com&size=128
   alexwlchan:
     feed_url: https://alexwlchan.net/atom.xml
     display_name: Alex Chan
     summary: Practical programming, software engineering, Python, and tooling.
+    profile_photo: https://alexwlchan.net/apple-touch-icon.png
   ned_batchelder:
     feed_url: https://nedbatchelder.com/blog/rss.xml
     display_name: Ned Batchelder
     summary: Python, software design, programming culture, and thoughtful technical essays.
+    profile_photo: https://avatars.githubusercontent.com/u/23789?s=200
   etsy_code_as_craft:
     feed_url: https://www.etsy.com/codeascraft/rss
     display_name: Etsy Code as Craft
     summary: Software engineering, infrastructure, developer culture, and technology at Etsy.
+    profile_photo: https://www.etsy.com/android-chrome-512x512.png
   discord_engineering:
     feed_url: https://discord.com/blog/rss.xml
     display_name: Discord Engineering
     summary: Distributed systems, infrastructure, performance, and engineering at Discord.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://discord.com&size=128
   soundcloud_backstage:
     feed_url: https://developers.soundcloud.com/blog/blog.rss
     display_name: SoundCloud Backstage
     summary: Developer infrastructure, distributed systems, APIs, and engineering at SoundCloud.
+    profile_photo: https://soundcloud.com/pwa-round-icon-512x512.png
   hugging_face:
     feed_url: https://huggingface.co/blog/feed.xml
     display_name: Hugging Face
     summary: Open machine learning, models, datasets, inference, and AI infrastructure.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://huggingface.co&size=128
   eric_meyer:
     feed_url: https://meyerweb.com/eric/thoughts/feed/
     display_name: Eric Meyer
     summary: Web standards, CSS, web development, and the evolution of the web.
+    profile_photo: https://meyerweb.com/apple-touch-icon.png
   josh_comeau:
     feed_url: https://www.joshwcomeau.com/rss.xml
     display_name: Josh Comeau
     summary: Frontend development, CSS, JavaScript, animation, and interactive web design.
+    profile_photo: https://www.joshwcomeau.com/favicon.png
   overreacted:
     feed_url: https://overreacted.io/rss.xml
     display_name: Overreacted
     summary: Programming, React, software abstractions, and thoughts on building software.
+    profile_photo: https://overreacted.io/icon.png?e0852c1e2c7f0e65
   great_synthesizers:
     feed_url: https://greatsynthesizers.com/en/feed/
     display_name: GreatSynthesizers
     summary: Synthesizer reviews, historical instruments, documentation, and sound examples.
+    profile_photo: https://greatsynthesizers.com/wp/wp-content/uploads/2018/08/cropped-sprechblase-blank-288x288.png
   synth_and_i:
     feed_url: https://synthandi.blogspot.com/feeds/posts/default?alt=rss
     display_name: The Synth and I
     summary: Synthesis, sound, electronic music, art, and creative inspiration.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://synthandi.blogspot.com&size=128
   vintage_synth_explorer:
     feed_url: https://feeds.feedburner.com/vintagesynth
     display_name: Vintage Synth Explorer
@@ -653,58 +686,72 @@ bots:
     feed_url: https://themillions.com/feed
     display_name: The Millions
     summary: Books, literature, publishing, and contemporary literary culture.
+    profile_photo: https://themillions.com/wp-content/themes/millions-v2/dist/images/apple-touch-icon.png
   public_books:
     feed_url: https://www.publicbooks.org/feed/
     display_name: Public Books
     summary: Literature, culture, politics, criticism, and ideas from scholars and writers.
+    profile_photo: https://www.publicbooks.org/wp-content/uploads/2020/09/cropped-favicon-2-300x300.png
   paris_review:
     feed_url: https://www.theparisreview.org/blog/feed/
     display_name: The Paris Review
     summary: Literature, writers, interviews, fiction, poetry, and literary culture.
+    profile_photo: https://www.theparisreview.org/images/favicons/apple-touch-icon.png
   lithub:
     feed_url: https://lithub.com/feed/
     display_name: Literary Hub
     summary: Books, literature, essays, publishing, and literary culture.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://lithub.com&size=128
   strong_towns:
     feed_url: https://www.strongtowns.org/journal/rss.xml
     display_name: Strong Towns
     summary: Cities, transportation, housing, walkability, and sustainable urban development.
+    profile_photo: https://cdn.prod.website-files.com/67ed6684112274e687cbf06e/68bb2b845bd31fd2886492e9_strong-towns_webclip.png
   places_journal:
     feed_url: https://feeds.feedburner.com/placesjournal
     display_name: Places Journal
     summary: Architecture, landscape, urbanism, design, and the built environment.
+    profile_photo: https://placesjournal.org/apple-touch-icon.png
   atlas_obscura:
     feed_url: https://www.atlasobscura.com/feeds/latest
     display_name: Atlas Obscura
     summary: Unusual places, history, culture, science, food, and the hidden world around us.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://www.atlasobscura.com&size=128
   lensculture:
     feed_url: https://www.lensculture.com/feeds/flipboard.rss
     display_name: LensCulture
     summary: Contemporary photography, photographers, visual culture, and photography criticism.
+    profile_photo: https://www.lensculture.com/icon.png
   petapixel:
     feed_url: https://petapixel.com/feed/
     display_name: PetaPixel
     summary: Photography, cameras, image-making technology, and photographic culture.
+    profile_photo: https://petapixel.com/assets/img/apple-touch-icon-180x180.png
   conscientious:
     feed_url: https://cphmag.com/feed-rss/
     display_name: Conscientious Photography
     summary: Contemporary photography, photographic books, exhibitions, and visual culture.
+    profile_photo: https://cphmag.com/apple-touch-icon-192x192.png
   magnum_photos:
     feed_url: https://www.magnumphotos.com/feed/
     display_name: Magnum Photos
     summary: Documentary photography, photojournalism, photographers, and visual storytelling.
+    profile_photo: https://www.magnumphotos.com/wp-content/themes/template/res/img/favicons/apple-touch-icon-180x180.png
   nautilus:
     feed_url: https://nautil.us/feed/
     display_name: Nautilus
     summary: Science, philosophy, culture, and big questions about the natural world.
+    profile_photo: https://lede-admin.nautil.us/wp-content/uploads/sites/70/sites/3/nautilus/cropped-thicker_smaller_logo.png
   aeon:
     feed_url: https://aeon.co/feed.rss
     display_name: Aeon
     summary: Philosophy, science, psychology, culture, and ideas about human life.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://aeon.co&size=128
   works_in_progress:
     feed_url: https://worksinprogress.co/rss.xml
     display_name: Works in Progress
     summary: Technology, science, economics, progress, infrastructure, and ideas for improving the world.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://worksinprogress.co&size=128
   henri_bergius:
     feed_url: https://bergie.iki.fi/blog/rss.xml
     display_name: Henri Bergius

--- a/feeds.yml
+++ b/feeds.yml
@@ -78,7 +78,7 @@ bots:
     summary: Articles from Dan Luu.
     profile_photo: https://avatars.githubusercontent.com/u/157136?s=200
   cassidoo:
-    feed_url: https://buttondown.email/cassidoo/rss
+    feed_url: https://buttondown.com/cassidoo/rss
     display_name: Cassidy Williams
     summary: rendezvous with cassidoo, a newsletter by Cassidy Williams.
     profile_photo: https://assets.buttondown.email/images/d40c16f2-c6ab-4a4f-b37f-e8e145580003.png
@@ -182,7 +182,7 @@ bots:
     summary: Fresh hacks every day from the hardware and maker community.
     profile_photo: https://hackaday.com/wp-content/themes/hackaday-2/img/logo.png
   craig_mod:
-    feed_url: https://craigmod.com/rss/
+    feed_url: https://craigmod.com/index.xml
     display_name: Craig Mod
     summary: Writing about walking, books, photography, and technology.
     profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://craigmod.com&size=128
@@ -457,7 +457,7 @@ bots:
     summary: Awe-inspiring advances in science and technology from Scientific American.
     profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://www.scientificamerican.com&size=128
   lifehacker:
-    feed_url: https://lifehacker.com/feed/
+    feed_url: https://lifehacker.com/feed/rss
     display_name: Lifehacker
     summary: Tips, tricks, and downloads for getting things done.
     profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://lifehacker.com&size=128
@@ -550,11 +550,11 @@ bots:
     display_name: GitHub Engineering
     summary: Engineering stories about developer tools, infrastructure, and software development.
   synth_anatomy:
-    feed_url: https://www.synthanatomy.com/feed
+    feed_url: https://synthanatomy.com/feed
     display_name: Synth Anatomy
     summary: News and reviews about synthesizers, music technology, and electronic music.
   synth_history:
-    feed_url: https://www.synthhistory.com/rss
+    feed_url: https://www.synthhistory.com/blog-feed.xml
     display_name: Synth History
     summary: Stories about the history, people, instruments, and culture of synthesizers.
   gwern:
@@ -562,7 +562,7 @@ bots:
     display_name: Gwern
     summary: Long-form research into AI, statistics, psychology, technology, and unusual corners of the internet.
   stanislas:
-    feed_url: https://www.stanislas.blog/feed/
+    feed_url: https://stanislas.blog/feed.xml
     display_name: Stanislas
     summary: Rust, Go, DevOps, networking, home automation, terminal tools, and software tinkering.
   adactio:
@@ -570,11 +570,11 @@ bots:
     display_name: Adactio
     summary: Web standards, web development, design, and the history and future of the web.
   figma:
-    feed_url: https://www.figma.com/blog/feed/
+    feed_url: https://www.figma.com/blog/feed/atom.xml
     display_name: Figma Engineering
     summary: Graphics, collaboration, frontend, infrastructure, and unusual engineering problems.
   sean_goedecke:
-    feed_url: https://seangoedecke.com/rss.xml
+    feed_url: https://www.seangoedecke.com/rss.xml
     display_name: Sean Goedecke
     summary: Software engineering, technical leadership, architecture, and engineering organizations.
   horizontalpitch:
@@ -586,7 +586,7 @@ bots:
     display_name: Mark Mosher
     summary: Experimental electronic music, synthesis, dark ambient, cinematic music, glitch, and multimedia.
   jondent:
-    feed_url: https://jondent.co.uk/feed/
+    feed_url: https://djjondent.blogspot.com/feeds/posts/default?alt=rss
     display_name: JonDent
     summary: Electronic music, synthesizers, DJing, production, art, travel, and culture.
   the_marginalian:
@@ -594,7 +594,7 @@ bots:
     display_name: The Marginalian
     summary: Art, science, literature, philosophy, creativity, and the human experience.
   public_domain_review:
-    feed_url: https://publicdomainreview.org/feed/
+    feed_url: https://publicdomainreview.org/rss.xml
     display_name: The Public Domain Review
     summary: Curated art, literature, history, science, and strange treasures from the public domain.
   scott_berkun:
@@ -610,7 +610,7 @@ bots:
     display_name: Ned Batchelder
     summary: Python, software design, programming culture, and thoughtful technical essays.
   etsy_code_as_craft:
-    feed_url: https://www.etsy.com/codeascraft/feed/
+    feed_url: https://www.etsy.com/codeascraft/rss
     display_name: Etsy Code as Craft
     summary: Software engineering, infrastructure, developer culture, and technology at Etsy.
   discord_engineering:
@@ -618,17 +618,13 @@ bots:
     display_name: Discord Engineering
     summary: Distributed systems, infrastructure, performance, and engineering at Discord.
   soundcloud_backstage:
-    feed_url: https://developers.soundcloud.com/blog/feed.xml
+    feed_url: https://developers.soundcloud.com/blog/blog.rss
     display_name: SoundCloud Backstage
     summary: Developer infrastructure, distributed systems, APIs, and engineering at SoundCloud.
   hugging_face:
     feed_url: https://huggingface.co/blog/feed.xml
     display_name: Hugging Face
     summary: Open machine learning, models, datasets, inference, and AI infrastructure.
-  lmsys:
-    feed_url: https://lmsys.org/blog/feed.xml
-    display_name: LMSYS
-    summary: Large language models, evaluation, inference, and AI research.
   eric_meyer:
     feed_url: https://meyerweb.com/eric/thoughts/feed/
     display_name: Eric Meyer
@@ -670,15 +666,11 @@ bots:
     display_name: Literary Hub
     summary: Books, literature, essays, publishing, and literary culture.
   strong_towns:
-    feed_url: https://www.strongtowns.org/journal?format=rss
+    feed_url: https://www.strongtowns.org/journal/rss.xml
     display_name: Strong Towns
     summary: Cities, transportation, housing, walkability, and sustainable urban development.
-  citylab:
-    feed_url: https://www.bloomberg.com/citylab/feed
-    display_name: Bloomberg CityLab
-    summary: Cities, urbanism, transportation, housing, architecture, and public policy.
   places_journal:
-    feed_url: https://placesjournal.org/feed/
+    feed_url: https://feeds.feedburner.com/placesjournal
     display_name: Places Journal
     summary: Architecture, landscape, urbanism, design, and the built environment.
   atlas_obscura:
@@ -686,7 +678,7 @@ bots:
     display_name: Atlas Obscura
     summary: Unusual places, history, culture, science, food, and the hidden world around us.
   lensculture:
-    feed_url: https://www.lensculture.com/rss
+    feed_url: https://www.lensculture.com/feeds/flipboard.rss
     display_name: LensCulture
     summary: Contemporary photography, photographers, visual culture, and photography criticism.
   petapixel:
@@ -694,7 +686,7 @@ bots:
     display_name: PetaPixel
     summary: Photography, cameras, image-making technology, and photographic culture.
   conscientious:
-    feed_url: https://www.conscientious.photography/rss
+    feed_url: https://cphmag.com/feed-rss/
     display_name: Conscientious Photography
     summary: Contemporary photography, photographic books, exhibitions, and visual culture.
   magnum_photos:

--- a/feeds.yml
+++ b/feeds.yml
@@ -762,6 +762,188 @@ bots:
     display_name: The Urbanist
     summary: Cities, transportation, housing, and urban policy in the Pacific Northwest.
     profile_photo: https://storage.ghost.io/c/19/31/1931222a-d1c5-42ac-8932-2ee3ac1f8927/content/images/size/w256h256/2026/01/urb-logo.png
+  rachelbythebay:
+    feed_url: https://rachelbythebay.com/w/atom.xml
+    display_name: Rachel by the Bay
+    summary: Systems administration, debugging war stories, distributed systems, and the operational reality of running software.
+  schneier:
+    feed_url: https://www.schneier.com/feed/atom/
+    display_name: Schneier on Security
+    summary: Security, cryptography, privacy, surveillance, and the politics of both.
+    profile_photo: https://www.schneier.com/wp-content/uploads/2020/06/cropped-favicon-1-192x192.png
+  fasterthanlime:
+    feed_url: https://fasterthanli.me/index.xml
+    display_name: fasterthanli.me
+    summary: Rust, systems programming, compilers, and long illustrated deep dives into how things actually work.
+    profile_photo: https://cdn.fasterthanli.me/content/img/favicon~679ae9c272874bba.webp
+  russcox:
+    feed_url: https://research.swtch.com/feed.atom
+    display_name: research!rsc
+    summary: Go, version control, programming language design, and computing history from Russ Cox.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://research.swtch.com&size=128
+  ken_shirriff:
+    feed_url: https://www.righto.com/feeds/posts/default
+    display_name: Ken Shirriff
+    summary: Chip reverse engineering, vintage computer restoration, silicon die photography, and electronics archaeology.
+  chris_siebenmann:
+    feed_url: https://utcc.utoronto.ca/~cks/space/blog/?atom
+    display_name: Wandering Thoughts
+    summary: Unix, system administration, networking, and the practical details of running infrastructure.
+  daniel_lemire:
+    feed_url: https://lemire.me/blog/feed/
+    display_name: Daniel Lemire
+    summary: Performance engineering, SIMD, parsing, data structures, and computer science research.
+    profile_photo: https://lemire.me/blog/wp-content/uploads/2015/10/profile2011_152.jpg
+  maggie_appleton:
+    feed_url: https://maggieappleton.com/rss.xml
+    display_name: Maggie Appleton
+    summary: Design, anthropology, programming, and illustrated essays about tools for thought.
+    profile_photo: https://maggieappleton.com/images/favicon/android-chrome-512x512.png
+  molly_white:
+    feed_url: https://www.citationneeded.news/rss/
+    display_name: Citation Needed
+    summary: Cryptocurrency, tech accountability, and critical reporting on the industry from Molly White.
+    profile_photo: https://www.citationneeded.news/content/images/size/w256h256/2024/01/cn-blue-square.png
+  terence_eden:
+    feed_url: https://shkspr.mobi/blog/feed/atom/
+    display_name: Terence Eden
+    summary: Open standards, accessibility, the web, and occasionally grumpy technology criticism.
+    profile_photo: https://shkspr.mobi/android-chrome-512x512.png
+  fabien_sanglard:
+    feed_url: https://fabiensanglard.net/rss.xml
+    display_name: Fabien Sanglard
+    summary: Game engine archaeology, graphics programming, hardware teardowns, and code review of classic software.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://fabiensanglard.net&size=128
+  ben_kuhn:
+    feed_url: https://www.benkuhn.net/rss/
+    display_name: Ben Kuhn
+    summary: Engineering management, productivity, decision making, and essays on working effectively.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://www.benkuhn.net&size=128
+  robin_sloan:
+    feed_url: https://www.robinsloan.com/feed.xml
+    display_name: Robin Sloan
+    summary: Writing, media, technology, olive oil, and speculative thinking about the internet.
+    profile_photo: https://www.robinsloan.com/img/dragon-moon-logotype-2025-256.png
+  antirez:
+    feed_url: https://antirez.com/rss
+    display_name: antirez
+    summary: Systems programming, C, databases, and notes from the creator of Redis.
+    profile_photo: https://avatars.githubusercontent.com/u/65632?s=200
+  fly_io:
+    feed_url: https://fly.io/blog/feed.xml
+    display_name: Fly.io
+    summary: Distributed systems, networking, edge computing, security, and infrastructure engineering.
+    profile_photo: https://fly.io/phx/ui/images/favicon/android-chrome-512x512.png
+  jane_street:
+    feed_url: https://blog.janestreet.com/feed.xml
+    display_name: Jane Street Tech Blog
+    summary: OCaml, functional programming, systems, and engineering at a quantitative trading firm.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://blog.janestreet.com&size=128
+  meta_engineering:
+    feed_url: https://engineering.fb.com/feed/
+    display_name: Engineering at Meta
+    summary: Infrastructure, distributed systems, AI, open source, and engineering at Meta scale.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://engineering.fb.com&size=128
+  slack_engineering:
+    feed_url: https://slack.engineering/feed/
+    display_name: Slack Engineering
+    summary: Backend infrastructure, mobile, performance, and engineering culture at Slack.
+    profile_photo: https://slack.engineering/wp-content/uploads/sites/7/2020/05/cropped-octothrope-1.png?w=192
+  airbnb_engineering:
+    feed_url: https://medium.com/feed/airbnb-engineering
+    display_name: Airbnb Tech Blog
+    summary: Data infrastructure, machine learning, mobile, and engineering practice at Airbnb.
+    profile_photo: https://a0.muscache.com/airbnb/static/icons/android-icon-192x192-c0465f9f0380893768972a31a614b670.png
+  vercel:
+    feed_url: https://vercel.com/atom
+    display_name: Vercel
+    summary: Frontend infrastructure, Next.js, edge computing, and web performance.
+    profile_photo: https://py8fhxnkzwtsqdo9.public.blob.vercel-storage.com/front/favicon/vercel/android-chrome-512x512.png
+  sentry:
+    feed_url: https://blog.sentry.io/feed.xml
+    display_name: Sentry Blog
+    summary: Error monitoring, observability, debugging, performance, and open source developer tooling.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://blog.sentry.io&size=128
+  signal:
+    feed_url: https://signal.org/blog/rss.xml
+    display_name: Signal Blog
+    summary: Private messaging, cryptography, protocol design, and the case for encryption.
+    profile_photo: https://signal.org/assets/images/favicon/android-chrome-512x512.png
+  gothamist:
+    feed_url: https://gothamist.com/feed
+    display_name: Gothamist
+    summary: News, politics, transit, food, and culture in New York City.
+    profile_photo: https://gothamist.com/android-chrome-512x512.png
+  the_city:
+    feed_url: https://www.thecity.nyc/feed/
+    display_name: THE CITY
+    summary: Nonprofit accountability journalism about New York City government and the people it serves.
+    profile_photo: https://i0.wp.com/www.thecityreporter.nyc/wp-content/uploads/2026/05/cropped-Untitled-design-4.png?fit=512%2C512&ssl=1
+  curbed:
+    feed_url: https://www.curbed.com/rss/index.xml
+    display_name: Curbed
+    summary: Cities, real estate, architecture, design, and the way New York is built and lived in.
+    profile_photo: https://assets.curbed.com/media/sites/curbed/icon.196x196.png
+  streetsblog_nyc:
+    feed_url: https://nyc.streetsblog.org/feed
+    display_name: Streetsblog NYC
+    summary: Transportation policy, cycling, transit, street safety, and car culture in New York City.
+    profile_photo: https://nyc.streetsblog.org/wp-content/uploads/sites/9/2023/10/cropped-Round-SB-NYC-Stroke-2160px.png?w=192
+  hudson_valley_one:
+    feed_url: https://hudsonvalleyone.com/feed/
+    display_name: Hudson Valley One
+    summary: News, politics, arts, and community reporting from Ulster County and the Hudson Valley.
+    profile_photo: https://ulsterpub.wpenginepowered.com/wp-content/uploads/2017/01/cropped-hv1-icon-1-192x192.png
+  longreads:
+    feed_url: https://longreads.com/feed/
+    display_name: Longreads
+    summary: Curated longform journalism, essays, reporting, and narrative nonfiction from across the web.
+    profile_photo: https://i0.wp.com/longreads.com/wp-content/uploads/2017/01/longreads-logo-sm-rgb.png?fit=512%2C512&quality=80&ssl=1
+  noema:
+    feed_url: https://www.noemamag.com/feed/
+    display_name: Noema Magazine
+    summary: Long essays on technology, geopolitics, philosophy, economics, and the future of governance.
+    profile_photo: https://www.noemamag.com/wp-content/uploads/2020/06/cropped-ms-icon-310x310-1-192x192.png
+  astral_codex_ten:
+    feed_url: https://www.astralcodexten.com/feed
+    display_name: Astral Codex Ten
+    summary: Psychiatry, statistics, forecasting, medicine, and long arguments about how to think clearly.
+    profile_photo: https://substackcdn.com/image/fetch/$s_!o6Of!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F8c00a032-defa-44b7-9ab7-b7cc6d88db75%2Fapple-touch-icon-1024x1024.png
+  marginal_revolution:
+    feed_url: https://marginalrevolution.com/feed
+    display_name: Marginal Revolution
+    summary: Economics, books, culture, food, and daily links from Tyler Cowen and Alex Tabarrok.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://marginalrevolution.com&size=128
+  asterisk:
+    feed_url: https://asteriskmag.com/feed
+    display_name: Asterisk Magazine
+    summary: Rigorous writing on forecasting, biosecurity, economics, AI, and global development.
+    profile_photo: https://asteriskmag.com/assets/favicon/apple-touch-icon.png
+  colossal:
+    feed_url: https://www.thisiscolossal.com/feed/
+    display_name: Colossal
+    summary: Contemporary art, craft, illustration, sculpture, photography, and visual invention.
+    profile_photo: https://www.thisiscolossal.com/wp-content/uploads/2024/08/icon-crow.png
+  aperture:
+    feed_url: https://aperture.org/feed/
+    display_name: Aperture
+    summary: Photography, photobooks, exhibitions, and criticism from the Aperture Foundation.
+    profile_photo: https://aperture.org/wp-content/uploads/2023/05/cropped-v2_favicon-32x32-2-192x192.png
+  undark:
+    feed_url: https://undark.org/feed/
+    display_name: Undark Magazine
+    summary: Science journalism at the intersection of research, policy, medicine, and society.
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://undark.org&size=128
+  nasa:
+    feed_url: https://www.nasa.gov/feed/
+    display_name: NASA
+    summary: Missions, spaceflight, astronomy, Earth science, and research from NASA.
+    profile_photo: https://www.nasa.gov/wp-content/plugins/nasa-hds-core-setup/assets/favicons/android-chrome-512x512.png
+  bedroom_producers:
+    feed_url: https://bedroomproducersblog.com/feed/
+    display_name: Bedroom Producers Blog
+    summary: Free VST plugins, samples, music production tools, and bedroom studio gear.
+    profile_photo: https://bedroomproducersblog.com/wp-content/uploads/2020/06/cropped-bpb-icon-192x192.jpg
 relay_subscription_bot: nyt_homepage
 follows:
   - '@icco@merveilles.town'

--- a/feeds.yml
+++ b/feeds.yml
@@ -710,7 +710,7 @@ bots:
     display_name: Aeon
     summary: Philosophy, science, psychology, culture, and ideas about human life.
   works_in_progress:
-    feed_url: https://worksinprogress.co/feed/
+    feed_url: https://worksinprogress.co/rss.xml
     display_name: Works in Progress
     summary: Technology, science, economics, progress, infrastructure, and ideas for improving the world.
   henri_bergius:


### PR DESCRIPTION
Added a bunch of feeds in #126, this fixes some and adds missing photos.

Also adds yamllint config.

## Feed URLs

Fixed the 12 feeds failing on /status. Nine had a working replacement:

| Bot | Was | Now |
| --- | --- | --- |
| `conscientious` | `www.conscientious.photography/rss` (NXDOMAIN) | `cphmag.com/feed-rss/` — same publication, new domain |
| `etsy_code_as_craft` | `/codeascraft/feed/` (403) | `/codeascraft/rss` |
| `figma` | `/blog/feed/` (404) | `/blog/feed/atom.xml` |
| `jondent` | `jondent.co.uk/feed/` (NXDOMAIN) | `djjondent.blogspot.com/feeds/posts/default?alt=rss` |
| `lensculture` | `/rss` (404) | `/feeds/flipboard.rss` |
| `places_journal` | `placesjournal.org/feed/` (403) | `feeds.feedburner.com/placesjournal` — origin WAF-blocks bots, mirror is current |
| `soundcloud_backstage` | `/blog/feed.xml` (404) | `/blog/blog.rss` |
| `stanislas` | `www.stanislas.blog/feed/` (404) | `stanislas.blog/feed.xml` |
| `synth_history` | `/rss` (404) | `/blog-feed.xml` (Wix) |

`citylab` and `lmsys` are removed — neither publishes a working feed anywhere. Bloomberg serves a bot interstitial for every CityLab URL; LMSYS's generator writes `public/rss.xml` but the deployed site 404s it. The twelfth, `works_in_progress`, was fixed in 93fe754.

Seven more only worked via redirect and now point at the canonical URL: `cassidoo`, `craig_mod`, `lifehacker`, `public_domain_review`, `sean_goedecke`, `strong_towns`, `synth_anatomy`. Left alone: `gwern` and the two NPR podcasts, whose redirects are publisher-owned.

## Profile photos

47 added to existing bots. Preference order: the site's own apple-touch-icon or manifest icon, then a GitHub avatar for individual authors (matching the existing convention), then the gstatic favicon proxy for sites publishing only `.ico` or SVG. Candidates were screened on aspect ratio and pixel size, so `og:image` banners and WordPress's `s0.wp.com/i/blank.jpg` placeholder were rejected rather than committed.

`synthtopia` and `vintage_synth_explorer` publish no usable icon and stay unset.

## New feeds

37 added — developer and engineering blogs, NYC/Hudson Valley news, longform, photography, science, music production. 34 got photos from the same pipeline; `rachelbythebay`, `ken_shirriff`, and `chris_siebenmann` publish none.

Not added, having failed verification: Sound on Sound (410), Ableton and Sonicstate (404), Perfect Circuit / The Baffler / British Journal of Photography (403 to bots), Emergence Magazine and Bad Astronomy (feed parses but is empty), Uber and Shopify engineering (no live feed).

⚠️ **`rachelbythebay` and `chris_siebenmann` are worth reconsidering.** Both fetch fine on first contact but block a single IP after modest repeated polling — rachelbythebay.com now refuses connections entirely and utcc.utoronto.ca returns a sustained 429, both still blocked 15 minutes after testing stopped. At `POLL_INTERVAL_MS=300000` each bot hits its feed 288×/day from one host, which is what they appear to be defending against.

## Verification

- Every `feed_url` fetched and parsed with the app's own `fetchFeedWithHttpResult` — 188 bots, no errors, no empty feeds (before the two hosts above started throttling).
- `pnpm validate-feeds` passes on all 183 photos.
- `public_books` was swapped to the proxy after CI caught its host refusing GitHub runner IPs — same class as #122/#129. `magnum_photos` 403s to runners but that is a warning, not a failure.

## Test plan

- [ ] CI passes
- [ ] /status shows all feeds at HTTP 200 after deploy
