### PR TITLE
fix: mobile layout, tags pagination, and a 32-character hashtag limit

### DIFF
--- a/drizzle/0013_trim_long_hashtags.sql
+++ b/drizzle/0013_trim_long_hashtags.sql
@@ -1,0 +1,19 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Drop stored hashtags longer than MAX_TAG_LEN (32). These predate the length
+-- rule and render as unreadable one-word walls on /tags.
+UPDATE feed_entries
+SET hashtags = COALESCE(
+  (
+    SELECT jsonb_agg(t.v)
+    FROM jsonb_array_elements_text(hashtags) AS t(v)
+    WHERE length(t.v) <= 32
+  ),
+  '[]'::jsonb
+)
+WHERE jsonb_typeof(hashtags) = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements_text(hashtags) AS t(v)
+    WHERE length(t.v) > 32
+  );

--- a/drizzle/0013_trim_long_hashtags.sql
+++ b/drizzle/0013_trim_long_hashtags.sql
@@ -2,11 +2,13 @@
 
 -- Drop stored hashtags longer than MAX_TAG_LEN (32). These predate the length
 -- rule and render as unreadable one-word walls on /tags.
+-- WITH ORDINALITY + ORDER BY: tags render in stored order, and jsonb_agg makes
+-- no ordering promise without it.
 UPDATE feed_entries
 SET hashtags = COALESCE(
   (
-    SELECT jsonb_agg(t.v)
-    FROM jsonb_array_elements_text(hashtags) AS t(v)
+    SELECT jsonb_agg(t.v ORDER BY t.ord)
+    FROM jsonb_array_elements_text(hashtags) WITH ORDINALITY AS t(v, ord)
     WHERE length(t.v) <= 32
   ),
   '[]'::jsonb

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,495 @@
+{
+  "id": "750db165-671f-441d-8378-7405339cad19",
+  "prevId": "8ea87930-c919-490c-9898-ffd89faf0e48",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor_keypairs": {
+      "name": "actor_keypairs",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_entries": {
+      "name": "feed_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "feed_entries_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boost_count": {
+          "name": "boost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feed_entries_hashtags_gin_idx": {
+          "name": "feed_entries_hashtags_gin_idx",
+          "columns": [
+            {
+              "expression": "hashtags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "feed_entries_published_at_idx": {
+          "name": "feed_entries_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_entries_bot_username_guid_unique": {
+          "name": "feed_entries_bot_username_guid_unique",
+          "columns": [
+            "bot_username",
+            "guid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_poll_status": {
+      "name": "feed_poll_status",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followers": {
+      "name": "followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "followers_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_id": {
+          "name": "follow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followers_bot_username_follower_id_unique": {
+          "name": "followers_bot_username_follower_id_unique",
+          "columns": [
+            "bot_username",
+            "follower_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.following": {
+      "name": "following",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "following_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_actor_id": {
+          "name": "target_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "following_bot_username_handle_unique": {
+          "name": "following_bot_username_handle_unique",
+          "columns": [
+            "bot_username",
+            "handle"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relays": {
+      "name": "relays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "relays_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "relay_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "relays_bot_username_url_unique": {
+          "name": "relays_bot_username_url_unique",
+          "columns": [
+            "bot_username",
+            "url"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.relay_status": {
+      "name": "relay_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1776983700511,
       "tag": "0012_aspiring_tiger_shark",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1786739564390,
+      "tag": "0013_trim_long_hashtags",
+      "breakpoints": true
     }
   ]
 }

--- a/feeds.schema.json
+++ b/feeds.schema.json
@@ -80,7 +80,7 @@
           "items": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 30
+            "maxLength": 32
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fedify/vocab": "^2.3.4",
     "@google/genai": "^2.17.0",
     "@heroicons/react": "^2.2.0",
-    "@icco/react-common": "^2026.10811.3",
+    "@icco/react-common": "^2026.10814.2",
     "@js-temporal/polyfill": "^0.5.1",
     "@logtape/logtape": "^2.3.1",
     "daisyui": "^5.7.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.8)
       '@icco/react-common':
-        specifier: ^2026.10811.3
-        version: 2026.10811.3(@heroicons/react@2.2.0(react@19.2.8))(jsdom@30.0.0)(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        specifier: ^2026.10814.2
+        version: 2026.10814.2(@heroicons/react@2.2.0(react@19.2.8))(jsdom@30.0.0)(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@js-temporal/polyfill':
         specifier: ^0.5.1
         version: 0.5.1
@@ -479,8 +479,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@icco/react-common@2026.10811.3':
-    resolution: {integrity: sha512-deru/nPW5farxnLqE4/j4m1+cxYRgNY0WHK4lBp6w3L6O7e0KRIoKKKfRwWDYhmNWSnTUvMQwI2U78I1OgN6CA==, tarball: https://npm.pkg.github.com/download/@icco/react-common/2026.10811.3/06de76ce3b290c31b874288b864cc84f58c4a5ea}
+  '@icco/react-common@2026.10814.2':
+    resolution: {integrity: sha512-fCsw08PjPTL/cUqGzR2aJQM/x1vH9tP2pEsdkyV5+Giq9yJcSGNzJtuvCR8tU/OOYq17xzlnvSNzgegBkJ8Fyw==, tarball: https://npm.pkg.github.com/download/@icco/react-common/2026.10814.2/89e74e75a13f209e4fe14b67b9f7c1d8cc14f602}
     peerDependencies:
       '@heroicons/react': ^2.0.0
       jsdom: '>=20.0.0'
@@ -1181,8 +1181,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.13:
-    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+  baseline-browser-mapping@2.11.14:
+    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2607,7 +2607,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@icco/react-common@2026.10811.3(@heroicons/react@2.2.0(react@19.2.8))(jsdom@30.0.0)(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@icco/react-common@2026.10814.2(@heroicons/react@2.2.0(react@19.2.8))(jsdom@30.0.0)(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@heroicons/react': 2.2.0(react@19.2.8)
       '@wrksz/themes': 1.2.0(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
@@ -3185,7 +3185,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.13: {}
+  baseline-browser-mapping@2.11.14: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3737,7 +3737,7 @@ snapshots:
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.11.13
+      baseline-browser-mapping: 2.11.14
       caniuse-lite: 1.0.30001809
       postcss: 8.5.26
       react: 19.2.8

--- a/src/app/bot/[username]/page.tsx
+++ b/src/app/bot/[username]/page.tsx
@@ -96,13 +96,13 @@ export default async function BotProfilePage({ params, searchParams }: Props) {
               {bot.feed_url}
             </a>
           </p>
-          <div className="flex items-center gap-3 mt-3 flex-wrap">
+          <div className="flex flex-col items-stretch gap-3 mt-3 sm:flex-row sm:flex-wrap sm:items-center">
             <FollowButton account={`${username}@${domain}`}>
               <button type="button" className="btn btn-primary btn-sm">
                 Follow on Mastodon
               </button>
             </FollowButton>
-            <div className="stats stats-vertical shadow bg-base-200 sm:stats-horizontal">
+            <div className="stats stats-horizontal shadow bg-base-200">
               <div className="stat px-4 py-2">
                 <div className="stat-title text-xs">Posts</div>
                 <div className="stat-value text-lg">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,24 +12,16 @@
   --font-body: "Roboto", sans-serif;
 }
 
-/*
- * Feed titles, hashtags, and actor URLs are all external input, and a single
- * long token (a 51-character hashtag, a URL in a post title) otherwise
- * overflows the viewport. Only affects words that wouldn't fit anyway.
- */
+/* Feed titles, hashtags, and actor URLs are external input: one long token
+   otherwise overflows the viewport. */
 @layer base {
   body {
     overflow-wrap: break-word;
   }
 }
 
-/*
- * SiteHeader (@icco/react-common) hard-codes `px-8` gutters on a nav that
- * can't wrap, which overflowed the viewport on phones and left the header
- * misaligned with the main column. Drop its gutters — the wrapper supplies
- * them, matching <main> and the footer — and let the nav wrap when the brand
- * plus links don't fit on one line.
- */
+/* SiteHeader (@icco/react-common) hard-codes px-8 on a nav that can't wrap,
+   which overflows phones. The wrapper supplies the gutters instead. */
 .site-header nav {
   flex-wrap: wrap;
   gap: 0.25rem 1rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,17 @@
 }
 
 /*
+ * Feed titles, hashtags, and actor URLs are all external input, and a single
+ * long token (a 51-character hashtag, a URL in a post title) otherwise
+ * overflows the viewport. Only affects words that wouldn't fit anyway.
+ */
+@layer base {
+  body {
+    overflow-wrap: break-word;
+  }
+}
+
+/*
  * SiteHeader (@icco/react-common) hard-codes `px-8` gutters on a nav that
  * can't wrap, which overflowed the viewport on phones and left the header
  * misaligned with the main column. Drop its gutters — the wrapper supplies

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,3 +11,26 @@
   --font-display: "Roboto Mono", monospace;
   --font-body: "Roboto", sans-serif;
 }
+
+/*
+ * SiteHeader (@icco/react-common) hard-codes `px-8` gutters on a nav that
+ * can't wrap, which overflowed the viewport on phones and left the header
+ * misaligned with the main column. Drop its gutters — the wrapper supplies
+ * them, matching <main> and the footer — and let the nav wrap when the brand
+ * plus links don't fit on one line.
+ */
+.site-header nav {
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  padding-block: 1.5rem;
+}
+
+.site-header nav > div {
+  padding-inline: 0;
+}
+
+@media (width >= 40rem) {
+  .site-header nav {
+    padding-block: 2rem;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,21 +19,3 @@
     overflow-wrap: break-word;
   }
 }
-
-/* SiteHeader (@icco/react-common) hard-codes px-8 on a nav that can't wrap,
-   which overflows phones. The wrapper supplies the gutters instead. */
-.site-header nav {
-  flex-wrap: wrap;
-  gap: 0.25rem 1rem;
-  padding-block: 1.5rem;
-}
-
-.site-header nav > div {
-  padding-inline: 0;
-}
-
-@media (width >= 40rem) {
-  .site-header nav {
-    padding-block: 2rem;
-  }
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,42 +61,40 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     >
       <body className="min-h-screen flex flex-col bg-base-100 font-body">
         <WebVitals analyticsPath="/analytics/robot-villas" />
-        <div className="site-header container mx-auto w-full max-w-4xl px-4">
-          <SiteHeader
-            showThemeToggle={false}
-            brand={
-              <Link
-                href="/"
-                className="text-lg sm:text-xl font-display font-bold tracking-tight hover:opacity-80 transition-opacity flex items-center gap-2"
-              >
-                <span className="text-xl sm:text-2xl">🤖</span>
-                <span>{domain}</span>
-              </Link>
-            }
-            links={[
-              {
-                name: "Posts",
-                href: "/posts",
-                icon: <QueueListIcon className="h-5 w-5" />,
-              },
-              {
-                name: "Tags",
-                href: "/tags",
-                icon: <TagIcon className="h-5 w-5" />,
-              },
-              {
-                name: "Stats",
-                href: "/stats",
-                icon: <ChartBarIcon className="h-5 w-5" />,
-              },
-              {
-                name: "Status",
-                href: "/status",
-                icon: <SignalIcon className="h-5 w-5" />,
-              },
-            ]}
-          />
-        </div>
+        <SiteHeader
+          showThemeToggle={false}
+          brand={
+            <Link
+              href="/"
+              className="text-lg sm:text-xl font-display font-bold tracking-tight hover:opacity-80 transition-opacity flex items-center gap-2"
+            >
+              <span className="text-xl sm:text-2xl">🤖</span>
+              <span>{domain}</span>
+            </Link>
+          }
+          links={[
+            {
+              name: "Posts",
+              href: "/posts",
+              icon: <QueueListIcon className="h-5 w-5" />,
+            },
+            {
+              name: "Tags",
+              href: "/tags",
+              icon: <TagIcon className="h-5 w-5" />,
+            },
+            {
+              name: "Stats",
+              href: "/stats",
+              icon: <ChartBarIcon className="h-5 w-5" />,
+            },
+            {
+              name: "Status",
+              href: "/status",
+              icon: <SignalIcon className="h-5 w-5" />,
+            },
+          ]}
+        />
         <main className="container mx-auto flex-1 px-4 py-8 max-w-4xl">
           {children}
         </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,40 +61,42 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     >
       <body className="min-h-screen flex flex-col bg-base-100 font-body">
         <WebVitals analyticsPath="/analytics/robot-villas" />
-        <SiteHeader
-          showThemeToggle={false}
-          brand={
-            <Link
-              href="/"
-              className="text-xl font-display font-bold tracking-tight hover:opacity-80 transition-opacity flex items-center gap-2"
-            >
-              <span className="text-2xl">🤖</span>
-              <span>{domain}</span>
-            </Link>
-          }
-          links={[
-            {
-              name: "Posts",
-              href: "/posts",
-              icon: <QueueListIcon className="h-5 w-5" />,
-            },
-            {
-              name: "Tags",
-              href: "/tags",
-              icon: <TagIcon className="h-5 w-5" />,
-            },
-            {
-              name: "Stats",
-              href: "/stats",
-              icon: <ChartBarIcon className="h-5 w-5" />,
-            },
-            {
-              name: "Status",
-              href: "/status",
-              icon: <SignalIcon className="h-5 w-5" />,
-            },
-          ]}
-        />
+        <div className="site-header container mx-auto w-full max-w-4xl px-4">
+          <SiteHeader
+            showThemeToggle={false}
+            brand={
+              <Link
+                href="/"
+                className="text-lg sm:text-xl font-display font-bold tracking-tight hover:opacity-80 transition-opacity flex items-center gap-2"
+              >
+                <span className="text-xl sm:text-2xl">🤖</span>
+                <span>{domain}</span>
+              </Link>
+            }
+            links={[
+              {
+                name: "Posts",
+                href: "/posts",
+                icon: <QueueListIcon className="h-5 w-5" />,
+              },
+              {
+                name: "Tags",
+                href: "/tags",
+                icon: <TagIcon className="h-5 w-5" />,
+              },
+              {
+                name: "Stats",
+                href: "/stats",
+                icon: <ChartBarIcon className="h-5 w-5" />,
+              },
+              {
+                name: "Status",
+                href: "/status",
+                icon: <SignalIcon className="h-5 w-5" />,
+              },
+            ]}
+          />
+        </div>
         <main className="container mx-auto flex-1 px-4 py-8 max-w-4xl">
           {children}
         </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,7 +70,7 @@ export default function HomePage() {
           <Link
             key={username}
             href={`/@${username}`}
-            className="flex items-center gap-3 p-3 rounded-lg hover:bg-base-200 transition-colors group"
+            className="flex items-center gap-3 px-1 py-3 sm:p-3 rounded-lg hover:bg-base-200 transition-colors group"
           >
             {bot.profile_photo ? (
               /* eslint-disable-next-line @next/next/no-img-element */
@@ -86,7 +86,7 @@ export default function HomePage() {
                 <CpuChipIcon className="w-4 h-4 text-base-content/50" />
               </div>
             )}
-            <div className="min-w-0">
+            <div className="min-w-0 break-words">
               <span className="font-mono text-sm font-semibold group-hover:text-primary transition-colors">
                 @{username}
               </span>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -44,9 +44,6 @@ export default async function StatsPage() {
 
   return (
     <>
-      <Link href="/" className="btn btn-ghost btn-sm gap-1 mb-6 -ml-2">
-        <span>&larr;</span> All bots
-      </Link>
       <h1 className="text-3xl font-display font-bold tracking-tight mb-6">
         Stats
       </h1>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -44,15 +44,6 @@ export default async function StatsPage() {
 
   return (
     <>
-      {filteredTopPosts.length > 0 && (
-        <>
-          <h2 className="text-xl font-display font-bold mt-8 mb-4">
-            Top Posts
-          </h2>
-          <PostFeed domain={domain} entries={filteredTopPosts} />
-        </>
-      )}
-
       <Link href="/" className="btn btn-ghost btn-sm gap-1 mb-6 -ml-2">
         <span>&larr;</span> All bots
       </Link>
@@ -82,6 +73,15 @@ export default async function StatsPage() {
           <div className="stat-value">{fmt(global.totalBoosts)}</div>
         </div>
       </div>
+
+      {filteredTopPosts.length > 0 && (
+        <>
+          <h2 className="text-xl font-display font-bold mt-8 mb-4">
+            Top Posts
+          </h2>
+          <PostFeed domain={domain} entries={filteredTopPosts} />
+        </>
+      )}
 
       <h2 className="text-xl font-display font-bold mt-8 mb-4">Per Bot</h2>
       <div className="overflow-x-auto">

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -112,7 +112,9 @@ export default async function StatusPage() {
                   const allAccepted = s && s.accepted === botCount;
                   return (
                     <tr key={url} className={allAccepted ? "text-success" : ""}>
-                      <td className="font-mono text-xs break-all">{url}</td>
+                      {/* min-w keeps the table's scroller from squeezing the
+                          URL into a few characters per line on phones. */}
+                      <td className="font-mono text-xs break-all min-w-48">{url}</td>
                       <td className="text-right">
                         <span className={total < botCount ? "text-warning font-semibold" : ""}>{total} / {botCount}</span>
                       </td>
@@ -198,7 +200,7 @@ export default async function StatusPage() {
                       </Link>
                     </td>
                     <td className="hidden sm:table-cell text-sm">{bot.display_name}</td>
-                    <td>
+                    <td className="min-w-48">
                       <a
                         href={bot.feed_url}
                         target="_blank"

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -112,8 +112,8 @@ export default async function StatusPage() {
                   const allAccepted = s && s.accepted === botCount;
                   return (
                     <tr key={url} className={allAccepted ? "text-success" : ""}>
-                      {/* min-w keeps the table's scroller from squeezing the
-                          URL into a few characters per line on phones. */}
+                      {/* min-w: the scroller otherwise squeezes this to a few
+                          characters per line on phones. */}
                       <td className="font-mono text-xs break-all min-w-48">{url}</td>
                       <td className="text-right">
                         <span className={total < botCount ? "text-warning font-semibold" : ""}>{total} / {botCount}</span>

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -49,10 +49,6 @@ export default async function TagPage({ params, searchParams }: Props) {
 
   return (
     <>
-      <Link href="/" className="btn btn-ghost btn-sm gap-1 mb-6 -ml-2">
-        <span>&larr;</span> All bots
-      </Link>
-
       <div className="mb-6">
         <h1 className="text-3xl font-display font-bold tracking-tight">
           #{displayTag}

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -3,7 +3,14 @@ export const dynamic = "force-dynamic";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getGlobals } from "@/lib/globals";
-import { getAllTags } from "@/lib/db";
+import { getTagsPage } from "@/lib/db";
+import { parsePageParam } from "@/lib/pagination";
+
+const PAGE_SIZE = 100;
+
+interface Props {
+  searchParams: Promise<{ page?: string }>;
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const { domain } = getGlobals();
@@ -13,29 +20,47 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function TagsPage() {
+export default async function TagsPage({ searchParams }: Props) {
   const { db } = getGlobals();
-  const tags = await getAllTags(db);
+
+  const { page: pageParam } = await searchParams;
+  const page = parsePageParam(pageParam);
+  const offset = page * PAGE_SIZE;
+
+  const { tags, total } = await getTagsPage(db, PAGE_SIZE, offset);
+
+  const hasNext = offset + tags.length < total;
+  const hasPrev = page > 0;
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   return (
     <>
       <div className="mb-6">
         <h1 className="text-3xl font-display font-bold tracking-tight">Tags</h1>
         <p className="text-base-content/60 mt-1">
-          {tags.length.toLocaleString("en-US")} tag{tags.length !== 1 ? "s" : ""}
+          {total.toLocaleString("en-US")} tag{total !== 1 ? "s" : ""}
+          {total > PAGE_SIZE && (
+            <>
+              {" · "}page {(page + 1).toLocaleString("en-US")} of{" "}
+              {pageCount.toLocaleString("en-US")}
+            </>
+          )}
         </p>
       </div>
 
       <ul className="divide-y divide-base-300">
         {tags.map(({ tag, postCount }) => (
-          <li key={tag} className="flex items-center justify-between py-2">
+          <li
+            key={tag}
+            className="flex items-baseline justify-between gap-x-4 py-2"
+          >
             <Link
               href={`/tags/${encodeURIComponent(tag)}`}
-              className="text-sm font-mono font-semibold text-base-content hover:underline underline-offset-2"
+              className="min-w-0 break-all text-sm font-mono font-semibold text-base-content hover:underline underline-offset-2"
             >
               #{tag}
             </Link>
-            <span className="text-xs text-base-content/50">
+            <span className="shrink-0 text-xs text-base-content/50 whitespace-nowrap">
               {postCount.toLocaleString("en-US")} post{postCount !== 1 ? "s" : ""}
             </span>
           </li>
@@ -43,7 +68,24 @@ export default async function TagsPage() {
       </ul>
 
       {tags.length === 0 && (
-        <p className="text-base-content/50 text-sm">No tags yet.</p>
+        <p className="text-base-content/50 text-sm">
+          {hasPrev ? "No tags on this page." : "No tags yet."}
+        </p>
+      )}
+
+      {(hasPrev || hasNext) && (
+        <div className="join mt-6">
+          {hasPrev && (
+            <Link href={`/tags?page=${page - 1}`} className="join-item btn btn-sm">
+              &laquo; Previous
+            </Link>
+          )}
+          {hasNext && (
+            <Link href={`/tags?page=${page + 1}`} className="join-item btn btn-sm">
+              Next &raquo;
+            </Link>
+          )}
+        </div>
       )}
     </>
   );

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -37,15 +37,19 @@ export default async function TagsPage({ searchParams }: Props) {
     <>
       <div className="mb-6">
         <h1 className="text-3xl font-display font-bold tracking-tight">Tags</h1>
-        <p className="text-base-content/60 mt-1">
-          {total.toLocaleString("en-US")} tag{total !== 1 ? "s" : ""}
-          {total > PAGE_SIZE && (
-            <>
-              {" · "}page {(page + 1).toLocaleString("en-US")} of{" "}
-              {pageCount.toLocaleString("en-US")}
-            </>
-          )}
-        </p>
+        {/* `total` comes from the page's own rows, so it's 0 on an
+            out-of-range page — don't claim the site has no tags there. */}
+        {(total > 0 || !hasPrev) && (
+          <p className="text-base-content/60 mt-1">
+            {total.toLocaleString("en-US")} tag{total !== 1 ? "s" : ""}
+            {total > PAGE_SIZE && (
+              <>
+                {" · "}page {(page + 1).toLocaleString("en-US")} of{" "}
+                {pageCount.toLocaleString("en-US")}
+              </>
+            )}
+          </p>
+        )}
       </div>
 
       <ul className="divide-y divide-base-300">

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -37,8 +37,7 @@ export default async function TagsPage({ searchParams }: Props) {
     <>
       <div className="mb-6">
         <h1 className="text-3xl font-display font-bold tracking-tight">Tags</h1>
-        {/* `total` comes from the page's own rows, so it's 0 on an
-            out-of-range page — don't claim the site has no tags there. */}
+        {/* `total` rides along on the page's rows, so it's 0 out of range. */}
         {(total > 0 || !hasPrev) && (
           <p className="text-base-content/60 mt-1">
             {total.toLocaleString("en-US")} tag{total !== 1 ? "s" : ""}

--- a/src/components/feed-entries.tsx
+++ b/src/components/feed-entries.tsx
@@ -42,7 +42,7 @@ export function PostFeed({
     <ul className="divide-y divide-base-300">
       {entries.map((e) => (
         <li key={e.id} className="flex flex-col gap-1 py-2 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
-          <p className="text-sm leading-relaxed min-w-0">
+          <p className="text-sm leading-relaxed min-w-0 break-words">
             {showBotHandle && (
               <>
                 <Link

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -125,11 +125,10 @@ describeWithDb("database", () => {
     });
   });
 
-  // Tag counts are global (not scoped to a bot), so these assertions assume a
-  // dedicated test database, which is what CI provisions.
+  // Tag counts are global, not per-bot, so these assume the dedicated test
+  // database CI provisions.
   describe("getTagsPage", () => {
-    // "shared" is on 3 entries, "alpha"/"beta"/"gamma" on 1 each, so paging
-    // over them exercises both the count ordering and the tag tie-break.
+    // "shared" on 3 entries, the rest on 1: exercises count order + tie-break.
     async function seedTags() {
       await insertEntry(db, "testbot", "t-1", "https://example.com/1", "T1", null, ["Shared", "Gamma"]);
       await insertEntry(db, "testbot", "t-2", "https://example.com/2", "T2", null, ["shared", "Beta"]);

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -125,60 +125,95 @@ describeWithDb("database", () => {
     });
   });
 
-  // Tag counts are global, not per-bot, so these assume the dedicated test
-  // database CI provisions.
+  // Tag counts are global, not per-bot, so every assertion here is relative to
+  // a baseline taken after cleanup and filtered to this prefix — the suite
+  // stays deterministic against a database that holds other bots' entries.
   describe("getTagsPage", () => {
-    // "shared" on 3 entries, the rest on 1: exercises count order + tie-break.
-    async function seedTags() {
-      await insertEntry(db, "testbot", "t-1", "https://example.com/1", "T1", null, ["Shared", "Gamma"]);
-      await insertEntry(db, "testbot", "t-2", "https://example.com/2", "T2", null, ["shared", "Beta"]);
-      await insertEntry(db, "bot_a", "t-3", "https://example.com/3", "T3", null, ["SHARED", "Alpha"]);
+    const PREFIX = "zztagfixture";
+    const SHARED = `${PREFIX}shared`;
+
+    /** All pages walked end to end, plus the total the query reports. */
+    async function walkAllPages(limit: number) {
+      const collected: Array<{ tag: string; postCount: number }> = [];
+      let total = 0;
+      for (let offset = 0; ; offset += limit) {
+        const page = await getTagsPage(db, limit, offset);
+        total = page.total || total;
+        collected.push(...page.tags);
+        if (page.tags.length < limit) {
+          break;
+        }
+      }
+      return { collected, total };
     }
 
-    it("orders by post count then tag, and reports the distinct-tag total", async () => {
+    const fixtureTags = (tags: Array<{ tag: string; postCount: number }>) =>
+      tags.filter((t) => t.tag.startsWith(PREFIX));
+
+    async function baselineTotal() {
+      return (await getTagsPage(db, 1, 0)).total;
+    }
+
+    // SHARED lands on 3 entries and the rest on 1 apiece, so ordering exercises
+    // the post-count sort and the tag tie-break that breaks its ties.
+    async function seedTags() {
+      await insertEntry(db, "testbot", "t-1", "https://example.com/1", "T1", null, [`${PREFIX}Shared`, `${PREFIX}Gamma`]);
+      await insertEntry(db, "testbot", "t-2", "https://example.com/2", "T2", null, [SHARED, `${PREFIX}Beta`]);
+      await insertEntry(db, "bot_a", "t-3", "https://example.com/3", "T3", null, [SHARED.toUpperCase(), `${PREFIX}Alpha`]);
+    }
+
+    it("orders by post count then tag, and counts each tag once", async () => {
+      const base = await baselineTotal();
       await seedTags();
 
-      const { tags, total } = await getTagsPage(db, 100, 0);
-      expect(total).toBe(4);
-      expect(tags).toEqual([
-        { tag: "shared", postCount: 3 },
-        { tag: "alpha", postCount: 1 },
-        { tag: "beta", postCount: 1 },
-        { tag: "gamma", postCount: 1 },
+      const { tags, total } = await getTagsPage(db, 10_000, 0);
+      expect(total).toBe(base + 4);
+      expect(fixtureTags(tags)).toEqual([
+        { tag: SHARED, postCount: 3 },
+        { tag: `${PREFIX}alpha`, postCount: 1 },
+        { tag: `${PREFIX}beta`, postCount: 1 },
+        { tag: `${PREFIX}gamma`, postCount: 1 },
       ]);
     });
 
     it("pages without dropping or repeating equally-ranked tags", async () => {
       await seedTags();
 
-      const first = await getTagsPage(db, 2, 0);
-      const second = await getTagsPage(db, 2, 2);
-      const third = await getTagsPage(db, 2, 4);
+      // Without the `tag ASC` tie-break, equal post counts order arbitrarily
+      // per query, so a walk like this both repeats and misses tags.
+      const { collected, total } = await walkAllPages(2);
 
-      expect(first.tags.map((t) => t.tag)).toEqual(["shared", "alpha"]);
-      expect(second.tags.map((t) => t.tag)).toEqual(["beta", "gamma"]);
-      expect(third.tags).toEqual([]);
-      expect(first.total).toBe(4);
-      expect(second.total).toBe(4);
+      expect(collected).toHaveLength(total);
+      expect(new Set(collected.map((t) => t.tag)).size).toBe(total);
+      expect(fixtureTags(collected).map((t) => t.tag)).toEqual([
+        SHARED,
+        `${PREFIX}alpha`,
+        `${PREFIX}beta`,
+        `${PREFIX}gamma`,
+      ]);
     });
 
     it("ignores soft-deleted entries", async () => {
+      const base = await baselineTotal();
       await seedTags();
       await db
         .update(schema.feedEntries)
         .set({ deletedAt: new Date() })
         .where(inArray(schema.feedEntries.botUsername, ["testbot"]));
 
-      const { tags, total } = await getTagsPage(db, 100, 0);
-      expect(total).toBe(2);
-      expect(tags).toEqual([
-        { tag: "alpha", postCount: 1 },
-        { tag: "shared", postCount: 1 },
+      const { tags, total } = await getTagsPage(db, 10_000, 0);
+      expect(total).toBe(base + 2);
+      expect(fixtureTags(tags)).toEqual([
+        { tag: `${PREFIX}alpha`, postCount: 1 },
+        { tag: SHARED, postCount: 1 },
       ]);
     });
 
-    it("returns an empty page and a zero total when there are no tags", async () => {
-      expect(await getTagsPage(db, 100, 0)).toEqual({ tags: [], total: 0 });
+    it("returns an empty page past the last one", async () => {
+      await seedTags();
+      const { total } = await getTagsPage(db, 1, 0);
+
+      expect(await getTagsPage(db, 100, total)).toEqual({ tags: [], total: 0 });
     });
   });
 

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -8,6 +8,7 @@ import {
   getExistingGuids,
   insertEntry,
   countEntriesForBots,
+  getTagsPage,
   getFollowers,
   addFollower,
   removeFollower,
@@ -121,6 +122,64 @@ describeWithDb("database", () => {
 
     it("returns 0 for an empty bot list", async () => {
       expect(await countEntriesForBots(db, [])).toBe(0);
+    });
+  });
+
+  // Tag counts are global (not scoped to a bot), so these assertions assume a
+  // dedicated test database, which is what CI provisions.
+  describe("getTagsPage", () => {
+    // "shared" is on 3 entries, "alpha"/"beta"/"gamma" on 1 each, so paging
+    // over them exercises both the count ordering and the tag tie-break.
+    async function seedTags() {
+      await insertEntry(db, "testbot", "t-1", "https://example.com/1", "T1", null, ["Shared", "Gamma"]);
+      await insertEntry(db, "testbot", "t-2", "https://example.com/2", "T2", null, ["shared", "Beta"]);
+      await insertEntry(db, "bot_a", "t-3", "https://example.com/3", "T3", null, ["SHARED", "Alpha"]);
+    }
+
+    it("orders by post count then tag, and reports the distinct-tag total", async () => {
+      await seedTags();
+
+      const { tags, total } = await getTagsPage(db, 100, 0);
+      expect(total).toBe(4);
+      expect(tags).toEqual([
+        { tag: "shared", postCount: 3 },
+        { tag: "alpha", postCount: 1 },
+        { tag: "beta", postCount: 1 },
+        { tag: "gamma", postCount: 1 },
+      ]);
+    });
+
+    it("pages without dropping or repeating equally-ranked tags", async () => {
+      await seedTags();
+
+      const first = await getTagsPage(db, 2, 0);
+      const second = await getTagsPage(db, 2, 2);
+      const third = await getTagsPage(db, 2, 4);
+
+      expect(first.tags.map((t) => t.tag)).toEqual(["shared", "alpha"]);
+      expect(second.tags.map((t) => t.tag)).toEqual(["beta", "gamma"]);
+      expect(third.tags).toEqual([]);
+      expect(first.total).toBe(4);
+      expect(second.total).toBe(4);
+    });
+
+    it("ignores soft-deleted entries", async () => {
+      await seedTags();
+      await db
+        .update(schema.feedEntries)
+        .set({ deletedAt: new Date() })
+        .where(inArray(schema.feedEntries.botUsername, ["testbot"]));
+
+      const { tags, total } = await getTagsPage(db, 100, 0);
+      expect(total).toBe(2);
+      expect(tags).toEqual([
+        { tag: "alpha", postCount: 1 },
+        { tag: "shared", postCount: 1 },
+      ]);
+    });
+
+    it("returns an empty page and a zero total when there are no tags", async () => {
+      expect(await getTagsPage(db, 100, 0)).toEqual({ tags: [], total: 0 });
     });
   });
 

--- a/src/lib/__tests__/hashtags.test.ts
+++ b/src/lib/__tests__/hashtags.test.ts
@@ -21,7 +21,7 @@ import {
   normalizeHashtagLabel,
   resolveHashtags,
 } from "../hashtags";
-import type { BotConfig } from "../config";
+import { MAX_TAG_LEN, type BotConfig } from "../config";
 import type { FeedEntry } from "../rss";
 
 const baseBot: BotConfig = {
@@ -63,6 +63,29 @@ describe("normalizeHashtagLabel", () => {
 
   it("returns null for empty after normalization", () => {
     expect(normalizeHashtagLabel("!!!")).toBeNull();
+  });
+
+  it("keeps a tag of exactly MAX_TAG_LEN and drops longer ones", () => {
+    expect(normalizeHashtagLabel("a".repeat(MAX_TAG_LEN))).toBe("a".repeat(MAX_TAG_LEN));
+    expect(normalizeHashtagLabel("a".repeat(MAX_TAG_LEN + 1))).toBeNull();
+  });
+
+  it("measures length after stripping, so punctuation doesn't count", () => {
+    expect(normalizeHashtagLabel("Los Angeles Organizing 1984")).toBe("LosAngelesOrganizing1984");
+    expect(
+      normalizeHashtagLabel("Los Angeles Organizing Committee for the Olympic Games 1984"),
+    ).toBeNull();
+  });
+});
+
+describe("hashtag length limit", () => {
+  it("skips over-length candidates but keeps the ones that follow", () => {
+    expect(mergeHashtagCandidates(["b".repeat(40), "Tech", "News"], 3)).toEqual(["Tech", "News"]);
+  });
+
+  it("drops over-length tags stored before the limit existed", () => {
+    expect(hashtagsForNoteBody(["losangelesorganizingcommitteefortheolympicgames1984", "news"]))
+      .toEqual(["news"]);
   });
 });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 const MAX_DISPLAY_NAME_LENGTH = 100;
 const MAX_SUMMARY_LENGTH = 500;
+/** Max characters per hashtag; longer candidates are dropped, not truncated. */
+export const MAX_TAG_LEN = 32;
 
 const BotSchema = z.object({
   feed_url: z.string().url(),
@@ -11,7 +13,7 @@ const BotSchema = z.object({
   summary: z.string().min(1).max(MAX_SUMMARY_LENGTH),
   profile_photo: z.string().url().optional(),
   /** Up to three default hashtags (no #); merged with feed categories before optional Gemini. */
-  default_hashtags: z.array(z.string().min(1).max(30)).max(3).optional(),
+  default_hashtags: z.array(z.string().min(1).max(MAX_TAG_LEN)).max(3).optional(),
 });
 
 export const FeedsConfigSchema = z

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -324,16 +324,37 @@ export async function countAllEntries(db: Db): Promise<number> {
   return rows[0]?.value ?? 0;
 }
 
-export async function getAllTags(db: Db): Promise<Array<{ tag: string; postCount: number }>> {
-  const result = await db.execute<{ tag: string; post_count: number }>(sql`
-    SELECT lower(t.v) AS tag, count(*)::int AS post_count
-    FROM ${schema.feedEntries},
-         jsonb_array_elements_text(${schema.feedEntries.hashtags}) AS t(v)
-    WHERE ${schema.feedEntries.deletedAt} IS NULL
-    GROUP BY lower(t.v)
-    ORDER BY count(*) DESC
+export interface TagsPage {
+  tags: Array<{ tag: string; postCount: number }>;
+  /** Total number of distinct tags, i.e. across every page. */
+  total: number;
+}
+
+/**
+ * One page of hashtags, most-used first. `tag ASC` is a required tie-break:
+ * most tags have the same (small) post count, and without it LIMIT/OFFSET
+ * ordering is unstable, so tags would repeat across pages while others never
+ * appeared. `count(*) OVER ()` computes the distinct-tag total in the same
+ * pass — window functions run before LIMIT — instead of a second full
+ * unnest + GROUP BY over every entry.
+ */
+export async function getTagsPage(db: Db, limit: number, offset: number): Promise<TagsPage> {
+  const result = await db.execute<{ tag: string; post_count: number; total: number }>(sql`
+    SELECT tag, post_count, (count(*) OVER ())::int AS total
+    FROM (
+      SELECT lower(t.v) AS tag, count(*)::int AS post_count
+      FROM ${schema.feedEntries},
+           jsonb_array_elements_text(${schema.feedEntries.hashtags}) AS t(v)
+      WHERE ${schema.feedEntries.deletedAt} IS NULL
+      GROUP BY lower(t.v)
+    ) AS grouped
+    ORDER BY post_count DESC, tag ASC
+    LIMIT ${limit} OFFSET ${offset}
   `);
-  return result.map((r) => ({ tag: r.tag, postCount: r.post_count }));
+  return {
+    tags: result.map((r) => ({ tag: r.tag, postCount: r.post_count })),
+    total: result[0]?.total ?? 0,
+  };
 }
 
 /**

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -332,11 +332,9 @@ export interface TagsPage {
 
 /**
  * One page of hashtags, most-used first. `tag ASC` is a required tie-break:
- * most tags have the same (small) post count, and without it LIMIT/OFFSET
- * ordering is unstable, so tags would repeat across pages while others never
- * appeared. `count(*) OVER ()` computes the distinct-tag total in the same
- * pass — window functions run before LIMIT — instead of a second full
- * unnest + GROUP BY over every entry.
+ * most tags share the same post count, so without it LIMIT/OFFSET repeats
+ * tags across pages and drops others. `count(*) OVER ()` gets the total in
+ * the same pass instead of a second unnest + GROUP BY over every entry.
  */
 export async function getTagsPage(db: Db, limit: number, offset: number): Promise<TagsPage> {
   const result = await db.execute<{ tag: string; post_count: number; total: number }>(sql`

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -1,17 +1,18 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { getLogger } from "@logtape/logtape";
-import type { BotConfig } from "./config";
+import { MAX_TAG_LEN, type BotConfig } from "./config";
 import type { FeedEntry } from "./rss";
 
 const logger = getLogger(["robot-villas", "hashtags"]);
 
 /** Max hashtags per note (stored and rendered). */
 export const MAX_TAGS = 3;
-const MAX_TAG_LEN = 30;
 const GEMINI_DEFAULT_MODEL = "gemini-2.5-flash-lite";
 
 /**
  * Normalizes a candidate label to a Mastodon-safe hashtag token (no leading #).
+ * Returns null past MAX_TAG_LEN: truncating a long label just yields a mangled
+ * word ("LosAngelesOrganizingCommitteeFo"), which is worse than no tag.
  */
 export function normalizeHashtagLabel(raw: string): string | null {
   let s = raw.trim().replace(/^#+/u, "");
@@ -20,11 +21,8 @@ export function normalizeHashtagLabel(raw: string): string | null {
   }
   s = s.normalize("NFKD").replace(/\p{M}/gu, "");
   s = s.replace(/[^a-zA-Z0-9_]/g, "");
-  if (!s) {
+  if (!s || s.length > MAX_TAG_LEN) {
     return null;
-  }
-  if (s.length > MAX_TAG_LEN) {
-    s = s.slice(0, MAX_TAG_LEN);
   }
   return s;
 }
@@ -139,7 +137,7 @@ Strategy:
 
 Format rules:
 - Each tag MUST be a single common word or well-known short compound (e.g. "Tech", "OpenSource", "Science", "Music").
-- Maximum 30 characters per tag. Prefer tags under 15 characters.
+- Maximum ${MAX_TAG_LEN} characters per tag (longer tags are discarded). Prefer tags under 15 characters.
 - ASCII letters, digits, underscore only; CamelCase; no # or spaces inside a tag.
 - Use recognizable topic tags, NOT article-specific phrases or proper nouns from the title.
 


### PR DESCRIPTION
## Mobile layout

`SiteHeader`'s hard-coded `px-8` on a nav that can't wrap made the header wider than a 390px viewport, so **every** page scrolled horizontally. It now sits in the same `max-w-4xl` container as `<main>` and the footer, with its gutters supplied by that wrapper. Long tokens (a 51-character hashtag, a URL in a post title) pushed pages ~900px wide; `overflow-wrap: break-word` in the base layer fixes that. Also: Follow button above the stats on bot profiles, min-width on the status page's URL columns, Top Posts moved below the Stats heading.

Verified against a local instance: zero horizontal overflow across 14 routes × 5 widths (320/390/430/768/1280).

## /tags pagination

The page rendered all 7,510 tags in one response. Now 100/page. `getTagsPage` replaces `getAllTags` and adds a `tag ASC` tie-break — ordering by count alone is unstable under LIMIT/OFFSET, so tags repeated across pages while others never appeared — and takes the total from the same query via `count(*) OVER ()`, so paginating costs no extra aggregate. Walking all pages renders each distinct tag exactly once.

## 32-character hashtag limit

Over-length candidates are now dropped rather than truncated; truncation is what produced fragments like `LosAngelesOrganizingCommitteeFo` in the first place. `MAX_TAG_LEN` lives in `config.ts` and is enforced in `normalizeHashtagLabel`, the Gemini prompt, the config schema, and `feeds.schema.json`. Migration `0013` strips existing tags over 32 characters from stored entries, keeping the rest of each row's tags.

Migration verified against a real postgres: a 51-character tag is dropped while its siblings survive, 32 is kept, 33 is not.