### PR TITLE
fix: poll feeds politely and stop crashing on attribute-only guids

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ The `relays` list contains ActivityPub relay actor URLs. The server subscribes t
 | `DATABASE_URL`      | PostgreSQL connection string                     | (required)         |
 | `DOMAIN`            | Public domain for ActivityPub IDs and WebFinger  | (required)         |
 | `PORT`              | HTTP server port                                 | `3000`             |
-| `POLL_INTERVAL_MS`  | Milliseconds between RSS poll cycles             | `300000` (5 min)   |
+| `POLL_INTERVAL_MS`  | Milliseconds between RSS poll cycles             | `3600000` (1 hour) |
 | `BLOCKED_INSTANCES` | Comma-separated hostnames to reject Follows from | (none)             |
 | `GEMINI_API_KEY`    | Google Gemini API key for AI hashtag suggestions | (none)             |
 | `GEMINI_PROJECT`    | GCP project for Vertex AI (alternative to key)   | (none)             |
 | `GEMINI_LOCATION`   | GCP region for Vertex AI                         | `us-central1`     |
 | `GEMINI_MODEL`      | Gemini model name                                | `gemini-2.5-flash` |
+
+The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Don't set `POLL_INTERVAL_MS` below an hour — feed hosts block fetchers that poll faster.
 
 ## Development
 

--- a/drizzle/0014_cloudy_miek.sql
+++ b/drizzle/0014_cloudy_miek.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "feed_poll_status" ADD COLUMN "etag" text;--> statement-breakpoint
+ALTER TABLE "feed_poll_status" ADD COLUMN "last_modified" text;--> statement-breakpoint
+ALTER TABLE "feed_poll_status" ADD COLUMN "next_poll_at" timestamp with time zone;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,513 @@
+{
+  "id": "60e14d4d-ba10-4415-81be-8e3f3676ba79",
+  "prevId": "750db165-671f-441d-8378-7405339cad19",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor_keypairs": {
+      "name": "actor_keypairs",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_entries": {
+      "name": "feed_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feed_entries_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boost_count": {
+          "name": "boost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feed_entries_hashtags_gin_idx": {
+          "name": "feed_entries_hashtags_gin_idx",
+          "columns": [
+            {
+              "expression": "hashtags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "feed_entries_published_at_idx": {
+          "name": "feed_entries_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_entries_bot_username_guid_unique": {
+          "name": "feed_entries_bot_username_guid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "guid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_poll_status": {
+      "name": "feed_poll_status",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followers": {
+      "name": "followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_id": {
+          "name": "follow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followers_bot_username_follower_id_unique": {
+          "name": "followers_bot_username_follower_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "follower_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.following": {
+      "name": "following",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "following_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_actor_id": {
+          "name": "target_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "following_bot_username_handle_unique": {
+          "name": "following_bot_username_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relays": {
+      "name": "relays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "relays_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "relay_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "relays_bot_username_url_unique": {
+          "name": "relays_bot_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.relay_status": {
+      "name": "relay_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1786739564390,
       "tag": "0013_trim_long_hashtags",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1786741789774,
+      "tag": "0014_cloudy_miek",
+      "breakpoints": true
     }
   ]
 }

--- a/feeds.yml
+++ b/feeds.yml
@@ -808,7 +808,7 @@ bots:
     feed_url: https://shkspr.mobi/blog/feed/atom/
     display_name: Terence Eden
     summary: Open standards, accessibility, the web, and occasionally grumpy technology criticism.
-    profile_photo: https://shkspr.mobi/android-chrome-512x512.png
+    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://shkspr.mobi&size=128
   fabien_sanglard:
     feed_url: https://fabiensanglard.net/rss.xml
     display_name: Fabien Sanglard

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { getGlobals } from "@/lib/globals";
 import { FEED_USER_AGENT } from "@/lib/rss";
 
@@ -20,7 +21,7 @@ export function generateMetadata(): Metadata {
   };
 }
 
-function Code({ children }: { children: React.ReactNode }) {
+function Code({ children }: { children: ReactNode }) {
   return (
     <code className="bg-base-300 px-1.5 py-0.5 rounded font-mono text-xs break-all">
       {children}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,117 @@
+import type { Metadata } from "next";
+import { getGlobals } from "@/lib/globals";
+import { FEED_USER_AGENT } from "@/lib/rss";
+
+export const dynamic = "force-dynamic";
+
+const REPO = "https://github.com/icco/robot.villas";
+const EDIT_FEEDS_URL = `${REPO}/edit/main/feeds.yml`;
+
+const DESCRIPTION =
+  "What robot.villas is, how to add a feed, and how its RSS fetcher behaves.";
+
+export function generateMetadata(): Metadata {
+  const { domain } = getGlobals();
+  return {
+    title: "About",
+    description: DESCRIPTION,
+    alternates: { canonical: `https://${domain}/about` },
+    openGraph: { title: `About – ${domain}`, description: DESCRIPTION, url: `https://${domain}/about` },
+  };
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="bg-base-300 px-1.5 py-0.5 rounded font-mono text-xs break-all">
+      {children}
+    </code>
+  );
+}
+
+export default function AboutPage() {
+  const { config, domain } = getGlobals();
+  const botCount = Object.keys(config.bots).length;
+
+  return (
+    <>
+      <h1 className="text-4xl font-display font-bold tracking-tight mb-4">About</h1>
+      <p className="text-base-content/80 text-lg leading-relaxed max-w-2xl mb-10">
+        {domain} mirrors {botCount} public RSS and Atom feeds onto the Fediverse. Each feed gets its
+        own bot account (<Code>@hackernews@{domain}</Code>) that posts new items, so you can follow a
+        blog from Mastodon or any ActivityPub server. It is open source and run for free by{" "}
+        <a href="https://natwelch.com" className="link link-primary">Nat Welch</a>.
+      </p>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-display font-bold mb-3">Adding a feed</h2>
+        <p className="text-base-content/80 mb-4">
+          Every bot is one entry in <Code>feeds.yml</Code>. Suggest a feed by opening a pull request
+          — or an <a href={`${REPO}/issues/new`} className="link link-primary">issue</a> with the URL
+          if you would rather not.
+        </p>
+        <ol className="list-decimal list-outside ml-5 space-y-3 text-base-content/80">
+          <li>
+            <a href={EDIT_FEEDS_URL} className="link link-primary">Edit <Code>feeds.yml</Code></a> and
+            add a block under <Code>bots:</Code>:
+            <pre className="bg-base-200 rounded-lg p-4 mt-2 overflow-x-auto text-xs font-mono">
+              {`  example_blog:
+    feed_url: https://example.com/feed.xml
+    display_name: Example Blog
+    summary: What the blog is about.
+    profile_photo: https://example.com/avatar.png  # optional
+    default_hashtags: [Electronics, Retrocomputing]  # optional, max 3`}
+            </pre>
+          </li>
+          <li>
+            The key becomes the handle, so it must be lowercase letters, numbers, or underscores.
+            <Code>display_name</Code> is capped at 100 characters and <Code>summary</Code> at 500.
+          </li>
+          <li>
+            Run <Code>pnpm validate-feeds</Code> to check the schema and that any{" "}
+            <Code>profile_photo</Code> is a reachable image. CI runs it too.
+          </li>
+          <li>Open the pull request. The bot goes live the next time the server deploys.</li>
+        </ol>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-display font-bold mb-3">Removing a feed</h2>
+        <p className="text-base-content/80">
+          If you publish a feed here and would rather not, delete its entry in a pull request or open
+          an issue and it will be removed. The bot account is deleted and its posts are withdrawn
+          from the Fediverse.
+        </p>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="text-2xl font-display font-bold mb-3">How the fetcher behaves</h2>
+        <p className="text-base-content/80 mb-4">
+          If you run a site listed on the <a href="/status" className="link link-primary">status page</a>,
+          this is what you will see in your logs:
+        </p>
+        <ul className="list-disc list-outside ml-5 space-y-2 text-base-content/80">
+          <li>
+            It identifies itself as <Code>{FEED_USER_AGENT}</Code>.
+          </li>
+          <li>Each feed is fetched at most once an hour.</li>
+          <li>
+            Requests are conditional (<Code>If-None-Match</Code> / <Code>If-Modified-Since</Code>),
+            so an unchanged feed costs you a 304 and no body.
+          </li>
+          <li>
+            A <Code>429</Code> pauses that feed until its <Code>Retry-After</Code> has passed.
+          </li>
+          <li>Only titles and links are reposted, each crediting your feed with a link back.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-display font-bold mb-3">Source</h2>
+        <p className="text-base-content/80">
+          <a href={REPO} className="link link-primary">github.com/icco/robot.villas</a> — bug reports
+          and feed suggestions welcome.
+        </p>
+      </section>
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Roboto, Roboto_Mono } from "next/font/google";
 import {
   ChartBarIcon,
+  InformationCircleIcon,
   QueueListIcon,
   SignalIcon,
   TagIcon,
@@ -92,6 +93,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
               name: "Status",
               href: "/status",
               icon: <SignalIcon className="h-5 w-5" />,
+            },
+            {
+              name: "About",
+              href: "/about",
+              icon: <InformationCircleIcon className="h-5 w-5" />,
             },
           ]}
         />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,6 +10,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     { url: `${base}/`, changeFrequency: "daily", priority: 1.0 },
     { url: `${base}/stats`, changeFrequency: "hourly", priority: 0.7 },
+    { url: `${base}/about`, changeFrequency: "monthly", priority: 0.5 },
   ];
 
   const botPages: MetadataRoute.Sitemap = Object.keys(config.bots).map(

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -60,7 +60,8 @@ export async function register() {
 
   const { startPoller } = await import("@/lib/poller");
   const { parsePositiveInt } = await import("@/lib/env");
-  const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 300_000);
+  // One hour: feed publishers treat anything faster as abuse (utcc.utoronto.ca returns 429).
+  const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 3_600_000);
   const pollConcurrency = parsePositiveInt(process.env.POLL_CONCURRENCY, 10);
 
   startPoller({

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -60,7 +60,7 @@ export async function register() {
 
   const { startPoller } = await import("@/lib/poller");
   const { parsePositiveInt } = await import("@/lib/env");
-  // One hour: feed publishers treat anything faster as abuse (utcc.utoronto.ca returns 429).
+  // One hour: feed hosts 429 fetchers that poll faster.
   const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 3_600_000);
   const pollConcurrency = parsePositiveInt(process.env.POLL_CONCURRENCY, 10);
 

--- a/src/lib/__tests__/poller.test.ts
+++ b/src/lib/__tests__/poller.test.ts
@@ -10,15 +10,45 @@ vi.mock("../publisher", () => ({
 
 vi.mock("../db", () => ({
   upsertFeedPollStatus: vi.fn().mockResolvedValue(undefined),
+  getFeedPollStatusMap: vi.fn().mockResolvedValue(new Map()),
 }));
 
-import { fetchFeedWithHttpResult } from "../rss";
+import { fetchFeedWithHttpResult, type FeedFetchResult } from "../rss";
 import { publishNewEntries } from "../publisher";
 import { startPoller } from "../poller";
+import { getFeedPollStatusMap, upsertFeedPollStatus, type FeedPollStatusRow } from "../db";
 import type { FeedsConfig } from "../config";
 
 const mockFetchFeed = vi.mocked(fetchFeedWithHttpResult);
 const mockPublishNewEntries = vi.mocked(publishNewEntries);
+const mockGetStatusMap = vi.mocked(getFeedPollStatusMap);
+const mockUpsertStatus = vi.mocked(upsertFeedPollStatus);
+
+/** A successful, unconditional fetch: parsed fine, nothing to back off from. */
+function okFetch(overrides: Partial<FeedFetchResult> = {}): FeedFetchResult {
+  return {
+    entries: [],
+    httpStatus: 200,
+    errorMessage: null,
+    notModified: false,
+    validators: { etag: null, lastModified: null },
+    retryAfterMs: null,
+    ...overrides,
+  };
+}
+
+function statusRow(overrides: Partial<FeedPollStatusRow> = {}): FeedPollStatusRow {
+  return {
+    botUsername: "bot0",
+    lastCheckedAt: new Date("2026-08-14T20:00:00Z"),
+    lastHttpStatus: 200,
+    lastError: null,
+    etag: null,
+    lastModified: null,
+    nextPollAt: null,
+    ...overrides,
+  };
+}
 
 function makeConfig(botCount: number): FeedsConfig {
   const bots: FeedsConfig["bots"] = {};
@@ -36,11 +66,12 @@ describe("startPoller concurrency", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPublishNewEntries.mockResolvedValue({ published: 0, skipped: 0 });
+    mockGetStatusMap.mockResolvedValue(new Map());
   });
 
   it("polls all configured bots", async () => {
     const botCount = 6;
-    mockFetchFeed.mockResolvedValue({ entries: [], httpStatus: 200, errorMessage: null });
+    mockFetchFeed.mockResolvedValue(okFetch());
 
     const poller = startPoller({
       config: makeConfig(botCount),
@@ -69,7 +100,7 @@ describe("startPoller concurrency", () => {
       maxActive = Math.max(maxActive, active);
       await new Promise((resolve) => setTimeout(resolve, 15));
       active--;
-      return { entries: [], httpStatus: 200, errorMessage: null };
+      return okFetch();
     });
 
     const poller = startPoller({
@@ -98,7 +129,7 @@ describe("startPoller concurrency", () => {
       if (feedUrl.includes("feed1")) {
         throw new Error("network error");
       }
-      return { entries: [], httpStatus: 200, errorMessage: null };
+      return okFetch();
     });
 
     const poller = startPoller({
@@ -119,7 +150,7 @@ describe("startPoller concurrency", () => {
 
   it("falls back to the default concurrency instead of polling zero bots when given NaN", async () => {
     const botCount = 3;
-    mockFetchFeed.mockResolvedValue({ entries: [], httpStatus: 200, errorMessage: null });
+    mockFetchFeed.mockResolvedValue(okFetch());
 
     const poller = startPoller({
       config: makeConfig(botCount),
@@ -134,6 +165,139 @@ describe("startPoller concurrency", () => {
       expect(mockFetchFeed).toHaveBeenCalledTimes(botCount);
     });
 
+    poller.stop();
+  });
+});
+
+describe("startPoller conditional GET and rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPublishNewEntries.mockResolvedValue({ published: 0, skipped: 0 });
+    mockGetStatusMap.mockResolvedValue(new Map());
+  });
+
+  function startOneBot() {
+    return startPoller({
+      config: makeConfig(1),
+      db: {} as never,
+      domain: "robot.villas",
+      intervalMs: 10_000_000,
+      concurrency: 1,
+      getContext: () => ({}) as never,
+    });
+  }
+
+  it("sends the stored validators with the next request", async () => {
+    mockGetStatusMap.mockResolvedValue(
+      new Map([["bot0", statusRow({ etag: '"abc"', lastModified: "yesterday" })]]),
+    );
+    mockFetchFeed.mockResolvedValue(okFetch({ httpStatus: 304, notModified: true }));
+
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockFetchFeed).toHaveBeenCalledTimes(1);
+    });
+    poller.stop();
+
+    expect(mockFetchFeed).toHaveBeenCalledWith("https://example.com/feed0.xml", {
+      etag: '"abc"',
+      lastModified: "yesterday",
+    });
+  });
+
+  it("does not publish anything when the feed is unmodified", async () => {
+    mockFetchFeed.mockResolvedValue(okFetch({ httpStatus: 304, notModified: true }));
+
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockUpsertStatus).toHaveBeenCalledTimes(1);
+    });
+    poller.stop();
+
+    expect(mockPublishNewEntries).not.toHaveBeenCalled();
+    expect(mockUpsertStatus.mock.calls[0][1]).toMatchObject({ lastError: null, lastHttpStatus: 304 });
+  });
+
+  it("keeps the stored validators when a fetch fails", async () => {
+    mockGetStatusMap.mockResolvedValue(
+      new Map([["bot0", statusRow({ etag: '"abc"', lastModified: "yesterday" })]]),
+    );
+    mockFetchFeed.mockResolvedValue(
+      okFetch({ httpStatus: 500, errorMessage: "HTTP 500", validators: null }),
+    );
+
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockUpsertStatus).toHaveBeenCalledTimes(1);
+    });
+    poller.stop();
+
+    expect(mockUpsertStatus.mock.calls[0][1]).toMatchObject({
+      etag: '"abc"',
+      lastModified: "yesterday",
+      nextPollAt: null,
+    });
+  });
+
+  it("records a backoff deadline when the server rate limits us", async () => {
+    mockFetchFeed.mockResolvedValue(
+      okFetch({
+        httpStatus: 429,
+        errorMessage: "HTTP 429",
+        validators: null,
+        retryAfterMs: 3_600_000,
+      }),
+    );
+
+    const before = Date.now();
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockUpsertStatus).toHaveBeenCalledTimes(1);
+    });
+    poller.stop();
+
+    const nextPollAt = mockUpsertStatus.mock.calls[0][1].nextPollAt;
+    expect(nextPollAt).toBeInstanceOf(Date);
+    expect(nextPollAt!.getTime()).toBeGreaterThanOrEqual(before + 3_600_000);
+  });
+
+  it("skips a feed that is still backing off, without overwriting its status", async () => {
+    mockGetStatusMap.mockResolvedValue(
+      new Map([
+        [
+          "bot0",
+          statusRow({
+            lastHttpStatus: 429,
+            lastError: "HTTP 429",
+            nextPollAt: new Date(Date.now() + 60_000),
+          }),
+        ],
+      ]),
+    );
+    mockFetchFeed.mockResolvedValue(okFetch());
+
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockGetStatusMap).toHaveBeenCalledTimes(1);
+    });
+    // Give the poll cycle a chance to (wrongly) fetch before asserting it didn't.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    poller.stop();
+
+    expect(mockFetchFeed).not.toHaveBeenCalled();
+    expect(mockUpsertStatus).not.toHaveBeenCalled();
+  });
+
+  it("polls again once the backoff deadline has passed", async () => {
+    mockGetStatusMap.mockResolvedValue(
+      new Map([["bot0", statusRow({ nextPollAt: new Date(Date.now() - 1_000) })]]),
+    );
+    mockFetchFeed.mockResolvedValue(okFetch());
+
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockFetchFeed).toHaveBeenCalledTimes(1);
+    });
     poller.stop();
   });
 });

--- a/src/lib/__tests__/poller.test.ts
+++ b/src/lib/__tests__/poller.test.ts
@@ -40,7 +40,8 @@ function okFetch(overrides: Partial<FeedFetchResult> = {}): FeedFetchResult {
 function statusRow(overrides: Partial<FeedPollStatusRow> = {}): FeedPollStatusRow {
   return {
     botUsername: "bot0",
-    lastCheckedAt: new Date("2026-08-14T20:00:00Z"),
+    // Old enough that the staleness gate never skips a bot that a test wants polled.
+    lastCheckedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
     lastHttpStatus: 200,
     lastError: null,
     etag: null,
@@ -286,6 +287,23 @@ describe("startPoller conditional GET and rate limiting", () => {
 
     expect(mockFetchFeed).not.toHaveBeenCalled();
     expect(mockUpsertStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fetch a feed checked less than an interval ago", async () => {
+    // A restart re-enters poll() immediately; without this gate every feed gets hit again.
+    mockGetStatusMap.mockResolvedValue(
+      new Map([["bot0", statusRow({ lastCheckedAt: new Date(Date.now() - 1_000) })]]),
+    );
+    mockFetchFeed.mockResolvedValue(okFetch());
+
+    const poller = startOneBot();
+    await vi.waitFor(() => {
+      expect(mockGetStatusMap).toHaveBeenCalledTimes(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    poller.stop();
+
+    expect(mockFetchFeed).not.toHaveBeenCalled();
   });
 
   it("polls again once the backoff deadline has passed", async () => {

--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   decodeHtmlEntities,
+  DEFAULT_RATE_LIMIT_BACKOFF_MS,
   extractFeedCategories,
+  FEED_USER_AGENT,
   fetchFeedWithHttpResult,
   MAX_ITEMS_PER_POLL,
+  MAX_RATE_LIMIT_BACKOFF_MS,
   normalizeTypography,
   parseFeedXml,
+  parseRetryAfterMs,
+  toFeedText,
   type FeedEntry,
 } from "../rss";
 import type { Item } from "rss-parser";
@@ -223,5 +228,179 @@ describe("fetchFeedWithHttpResult", () => {
     expect(r.httpStatus).toBe(200);
     expect(r.errorMessage).toBeNull();
     expect(r.entries.length).toBe(2);
+    expect(r.notModified).toBe(false);
+  });
+
+  it("sends an identifying User-Agent", async () => {
+    let seen: Headers | undefined;
+    globalThis.fetch = async (_url, init) => {
+      seen = new Headers(init?.headers);
+      return new Response(SAMPLE_RSS, { status: 200 });
+    };
+    await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(seen?.get("user-agent")).toBe(FEED_USER_AGENT);
+    expect(seen?.get("user-agent")).toMatch(/robot\.villas/);
+  });
+
+  it("sends stored validators as conditional GET headers", async () => {
+    let seen: Headers | undefined;
+    globalThis.fetch = async (_url, init) => {
+      seen = new Headers(init?.headers);
+      return new Response(SAMPLE_RSS, { status: 200 });
+    };
+    await fetchFeedWithHttpResult("https://example.com/feed.xml", {
+      etag: '"abc"',
+      lastModified: "Wed, 21 Oct 2015 07:28:00 GMT",
+    });
+    expect(seen?.get("if-none-match")).toBe('"abc"');
+    expect(seen?.get("if-modified-since")).toBe("Wed, 21 Oct 2015 07:28:00 GMT");
+  });
+
+  it("omits conditional headers when nothing is cached", async () => {
+    let seen: Headers | undefined;
+    globalThis.fetch = async (_url, init) => {
+      seen = new Headers(init?.headers);
+      return new Response(SAMPLE_RSS, { status: 200 });
+    };
+    await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(seen?.has("if-none-match")).toBe(false);
+    expect(seen?.has("if-modified-since")).toBe(false);
+  });
+
+  it("returns validators from a 200 so the next request can be conditional", async () => {
+    globalThis.fetch = async () =>
+      new Response(SAMPLE_RSS, {
+        status: 200,
+        headers: { ETag: '"v2"', "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT" },
+      });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.validators).toEqual({
+      etag: '"v2"',
+      lastModified: "Wed, 21 Oct 2015 07:28:00 GMT",
+    });
+  });
+
+  it("treats 304 as success with no entries", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 304 });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml", {
+      etag: '"abc"',
+      lastModified: null,
+    });
+    expect(r.httpStatus).toBe(304);
+    expect(r.errorMessage).toBeNull();
+    expect(r.notModified).toBe(true);
+    expect(r.entries).toEqual([]);
+  });
+
+  it("keeps the cached validators when a 304 repeats none of them", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 304 });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml", {
+      etag: '"abc"',
+      lastModified: "Wed, 21 Oct 2015 07:28:00 GMT",
+    });
+    expect(r.validators).toEqual({
+      etag: '"abc"',
+      lastModified: "Wed, 21 Oct 2015 07:28:00 GMT",
+    });
+  });
+
+  it("does not return validators for an unparseable body, so the body is retried", async () => {
+    globalThis.fetch = async () =>
+      new Response("this is not xml at all", { status: 200, headers: { ETag: '"v2"' } });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.errorMessage).not.toBeNull();
+    expect(r.validators).toBeNull();
+  });
+
+  it("does not return validators for an error response", async () => {
+    globalThis.fetch = async () => new Response("", { status: 500, headers: { ETag: '"v2"' } });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.validators).toBeNull();
+    expect(r.retryAfterMs).toBeNull();
+  });
+
+  it("honours Retry-After on a 429", async () => {
+    globalThis.fetch = async () =>
+      new Response("", { status: 429, headers: { "Retry-After": "120" } });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.httpStatus).toBe(429);
+    expect(r.errorMessage).toMatch(/429/);
+    expect(r.retryAfterMs).toBe(120_000);
+  });
+
+  it("falls back to a default backoff when a 429 carries no Retry-After", async () => {
+    globalThis.fetch = async () => new Response("", { status: 429 });
+    const r = await fetchFeedWithHttpResult("https://example.com/feed.xml");
+    expect(r.retryAfterMs).toBe(DEFAULT_RATE_LIMIT_BACKOFF_MS);
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  const NOW = Date.parse("2026-08-14T21:00:00Z");
+
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfterMs("30", NOW)).toBe(30_000);
+  });
+
+  it("parses an HTTP-date", () => {
+    expect(parseRetryAfterMs("Fri, 14 Aug 2026 21:05:00 GMT", NOW)).toBe(300_000);
+  });
+
+  it("clamps a past HTTP-date to zero", () => {
+    expect(parseRetryAfterMs("Fri, 14 Aug 2026 20:00:00 GMT", NOW)).toBe(0);
+  });
+
+  it("clamps an absurd delay to the maximum", () => {
+    expect(parseRetryAfterMs("99999999", NOW)).toBe(MAX_RATE_LIMIT_BACKOFF_MS);
+  });
+
+  it("returns null for a missing or unparseable value", () => {
+    expect(parseRetryAfterMs(null, NOW)).toBeNull();
+    expect(parseRetryAfterMs("soon", NOW)).toBeNull();
+  });
+});
+
+describe("toFeedText", () => {
+  it("passes strings through", () => {
+    expect(toFeedText("hello")).toBe("hello");
+  });
+
+  it("unwraps the text node of an attributed tag", () => {
+    expect(toFeedText({ _: "hello", $: { isPermaLink: "false" } })).toBe("hello");
+  });
+
+  it("returns an empty string for an attributes-only tag", () => {
+    // `<guid isPermaLink="false"></guid>`, as seen on undark.org, parses to this shape.
+    expect(toFeedText({ $: { isPermaLink: "false" } })).toBe("");
+  });
+
+  it("returns an empty string for missing values", () => {
+    expect(toFeedText(undefined)).toBe("");
+    expect(toFeedText(null)).toBe("");
+  });
+});
+
+describe("parseFeedXml with an attributes-only guid", () => {
+  const RSS_WITH_EMPTY_GUID = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Broken Guid Feed</title>
+    <link>https://example.com</link>
+    <description>Feed whose guid tag carries only attributes</description>
+    <item>
+      <title>A Post</title>
+      <link>https://example.com/a-post</link>
+      <guid isPermaLink="false"></guid>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+  it("falls back to the link instead of yielding a non-string guid", async () => {
+    const entries = await parseFeedXml(RSS_WITH_EMPTY_GUID);
+    expect(entries).toHaveLength(1);
+    expect(typeof entries[0].guid).toBe("string");
+    expect(entries[0].guid).toBe("https://example.com/a-post");
+    expect(entries[0].title).toBe("A Post");
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -856,21 +856,22 @@ export interface FeedPollStatusRow {
   lastCheckedAt: Date;
   lastHttpStatus: number | null;
   lastError: string | null;
+  etag: string | null;
+  lastModified: string | null;
+  nextPollAt: Date | null;
 }
 
 export async function upsertFeedPollStatus(
   db: Db,
-  botUsername: string,
-  lastCheckedAt: Date,
-  lastHttpStatus: number | null,
-  lastError: string | null,
+  status: FeedPollStatusRow,
 ): Promise<void> {
+  const { botUsername, ...rest } = status;
   await db
     .insert(schema.feedPollStatus)
-    .values({ botUsername, lastCheckedAt, lastHttpStatus, lastError })
+    .values(status)
     .onConflictDoUpdate({
       target: schema.feedPollStatus.botUsername,
-      set: { lastCheckedAt, lastHttpStatus, lastError },
+      set: rest,
     });
 }
 
@@ -887,6 +888,9 @@ export async function getFeedPollStatusMap(
       lastCheckedAt: schema.feedPollStatus.lastCheckedAt,
       lastHttpStatus: schema.feedPollStatus.lastHttpStatus,
       lastError: schema.feedPollStatus.lastError,
+      etag: schema.feedPollStatus.etag,
+      lastModified: schema.feedPollStatus.lastModified,
+      nextPollAt: schema.feedPollStatus.nextPollAt,
     })
     .from(schema.feedPollStatus)
     .where(inArray(schema.feedPollStatus.botUsername, botUsernames));

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -865,13 +865,13 @@ export async function upsertFeedPollStatus(
   db: Db,
   status: FeedPollStatusRow,
 ): Promise<void> {
-  const { botUsername, ...rest } = status;
+  const { lastCheckedAt, lastHttpStatus, lastError, etag, lastModified, nextPollAt } = status;
   await db
     .insert(schema.feedPollStatus)
     .values(status)
     .onConflictDoUpdate({
       target: schema.feedPollStatus.botUsername,
-      set: rest,
+      set: { lastCheckedAt, lastHttpStatus, lastError, etag, lastModified, nextPollAt },
     });
 }
 

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -12,6 +12,8 @@ const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
 /** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
  * poll cycle run far longer than intervalMs when polled fully sequentially. */
 const DEFAULT_CONCURRENCY = 10;
+/** Tolerance on the per-feed staleness check, so a cycle that runs a little long still polls. */
+const RECHECK_SLACK_MS = 60 * 1000;
 const logger = getLogger(["robot-villas", "poller"]);
 
 export interface PollerOptions {
@@ -50,6 +52,17 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
         logger.debug("Skipping {username}: backing off until {nextPollAt}", {
           username,
           nextPollAt: previous.nextPollAt.toISOString(),
+        });
+        return;
+      }
+      // The interval is process-local, so a restart (mist redeploys hourly) would otherwise
+      // re-fetch every feed no matter how recently it was hit. The slack keeps a normal cycle
+      // — which takes slightly longer than intervalMs — from skipping a turn and drifting.
+      const sinceLastCheck = checkedAt.getTime() - (previous?.lastCheckedAt.getTime() ?? 0);
+      if (previous && sinceLastCheck < intervalMs - RECHECK_SLACK_MS) {
+        logger.debug("Skipping {username}: checked {sinceLastCheck}ms ago", {
+          username,
+          sinceLastCheck,
         });
         return;
       }

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -12,8 +12,6 @@ const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
 /** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
  * poll cycle run far longer than intervalMs when polled fully sequentially. */
 const DEFAULT_CONCURRENCY = 10;
-/** Slack on the staleness check, so a cycle running a little long doesn't skip a turn. */
-const RECHECK_SLACK_MS = 60 * 1000;
 const logger = getLogger(["robot-villas", "poller"]);
 
 export interface PollerOptions {
@@ -56,7 +54,7 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
       }
       // The interval is process-local, so without this a restart re-fetches every feed.
       const sinceLastCheck = checkedAt.getTime() - (previous?.lastCheckedAt.getTime() ?? 0);
-      if (previous && sinceLastCheck < intervalMs - RECHECK_SLACK_MS) {
+      if (previous && sinceLastCheck < intervalMs) {
         logger.debug("Skipping {username}: checked {sinceLastCheck}ms ago", {
           username,
           sinceLastCheck,

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -2,12 +2,13 @@ import type { Context } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
 import type { BotConfig, FeedsConfig } from "./config";
 import { mapWithConcurrency } from "./concurrency";
-import { upsertFeedPollStatus, type Db } from "./db";
+import { getFeedPollStatusMap, upsertFeedPollStatus, type Db, type FeedPollStatusRow } from "./db";
 import { parsePositiveInt } from "./env";
 import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
-const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+/** Feed publishers expect at most one request per hour per feed; anything faster earns a 429. */
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
 /** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
  * poll cycle run far longer than intervalMs when polled fully sequentially. */
 const DEFAULT_CONCURRENCY = 10;
@@ -35,22 +36,50 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
     { botCount: botNames.length, botNames: botNames.join(", "), intervalMs, concurrency },
   );
 
-  async function pollBot(ctx: Context<void>, username: string, bot: BotConfig): Promise<void> {
+  async function pollBot(
+    ctx: Context<void>,
+    username: string,
+    bot: BotConfig,
+    previous: FeedPollStatusRow | undefined,
+  ): Promise<void> {
     const checkedAt = new Date();
     try {
-      const fetchResult = await fetchFeedWithHttpResult(bot.feed_url);
-      await upsertFeedPollStatus(
-        db,
-        username,
-        checkedAt,
-        fetchResult.httpStatus,
-        fetchResult.errorMessage,
-      );
+      // Honour a server-requested backoff without touching the stored status row, so the
+      // status page keeps showing the 429 that put this feed on hold.
+      if (previous?.nextPollAt && previous.nextPollAt.getTime() > checkedAt.getTime()) {
+        logger.debug("Skipping {username}: backing off until {nextPollAt}", {
+          username,
+          nextPollAt: previous.nextPollAt.toISOString(),
+        });
+        return;
+      }
+      const fetchResult = await fetchFeedWithHttpResult(bot.feed_url, {
+        etag: previous?.etag ?? null,
+        lastModified: previous?.lastModified ?? null,
+      });
+      await upsertFeedPollStatus(db, {
+        botUsername: username,
+        lastCheckedAt: checkedAt,
+        lastHttpStatus: fetchResult.httpStatus,
+        lastError: fetchResult.errorMessage,
+        etag: fetchResult.validators ? fetchResult.validators.etag : (previous?.etag ?? null),
+        lastModified: fetchResult.validators
+          ? fetchResult.validators.lastModified
+          : (previous?.lastModified ?? null),
+        nextPollAt:
+          fetchResult.retryAfterMs == null
+            ? null
+            : new Date(checkedAt.getTime() + fetchResult.retryAfterMs),
+      });
       if (fetchResult.errorMessage) {
         logger.warn("Feed poll failed for {username}: {message}", {
           username,
           message: fetchResult.errorMessage,
         });
+        return;
+      }
+      if (fetchResult.notModified) {
+        logger.info("Feed unchanged for {username} (HTTP 304)", { username });
         return;
       }
       const result = await publishNewEntries(ctx, db, username, domain, fetchResult.entries, bot);
@@ -71,10 +100,18 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
   async function poll(): Promise<void> {
     logger.info("Poll cycle starting");
     const ctx = getContext();
+    let statuses: Map<string, FeedPollStatusRow>;
+    try {
+      statuses = await getFeedPollStatusMap(db, botNames);
+    } catch (err) {
+      // Without stored validators we still poll, just unconditionally.
+      logger.error("Could not load feed poll status: {error}", { error: err });
+      statuses = new Map();
+    }
     await mapWithConcurrency(
       Object.entries(config.bots),
       concurrency,
-      ([username, bot]) => pollBot(ctx, username, bot),
+      ([username, bot]) => pollBot(ctx, username, bot, statuses.get(username)),
     );
     logger.info("Poll cycle complete");
   }

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -7,12 +7,12 @@ import { parsePositiveInt } from "./env";
 import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
-/** Feed publishers expect at most one request per hour per feed; anything faster earns a 429. */
+/** Feed hosts 429 fetchers that poll faster than hourly. */
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
 /** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
  * poll cycle run far longer than intervalMs when polled fully sequentially. */
 const DEFAULT_CONCURRENCY = 10;
-/** Tolerance on the per-feed staleness check, so a cycle that runs a little long still polls. */
+/** Slack on the staleness check, so a cycle running a little long doesn't skip a turn. */
 const RECHECK_SLACK_MS = 60 * 1000;
 const logger = getLogger(["robot-villas", "poller"]);
 
@@ -46,8 +46,7 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
   ): Promise<void> {
     const checkedAt = new Date();
     try {
-      // Honour a server-requested backoff without touching the stored status row, so the
-      // status page keeps showing the 429 that put this feed on hold.
+      // Don't touch the status row while backing off, so /status keeps showing the 429.
       if (previous?.nextPollAt && previous.nextPollAt.getTime() > checkedAt.getTime()) {
         logger.debug("Skipping {username}: backing off until {nextPollAt}", {
           username,
@@ -55,9 +54,7 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
         });
         return;
       }
-      // The interval is process-local, so a restart (mist redeploys hourly) would otherwise
-      // re-fetch every feed no matter how recently it was hit. The slack keeps a normal cycle
-      // — which takes slightly longer than intervalMs — from skipping a turn and drifting.
+      // The interval is process-local, so without this a restart re-fetches every feed.
       const sinceLastCheck = checkedAt.getTime() - (previous?.lastCheckedAt.getTime() ?? 0);
       if (previous && sinceLastCheck < intervalMs - RECHECK_SLACK_MS) {
         logger.debug("Skipping {username}: checked {sinceLastCheck}ms ago", {

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -73,22 +73,18 @@ export interface FeedFetchResult {
   httpStatus: number | null;
   /** Null when the feed was fetched with a 2xx/304 response and parsed successfully. */
   errorMessage: string | null;
-  /** True on 304: the feed is unchanged since `validators`, so there is nothing to publish. */
+  /** True on 304: unchanged since `validators`, so there is nothing to publish. */
   notModified: boolean;
   /**
-   * Validators to persist for the next request. Null means "keep whatever is stored" — an error
-   * response or an unparseable body must not overwrite validators, or the next conditional GET
-   * would get a 304 and we'd never retry the body.
+   * Validators to persist. Null means "keep the stored ones" — caching validators from an
+   * unparseable body would 304 forever and never retry it.
    */
   validators: ConditionalGetState | null;
-  /** How long the server asked us to wait before retrying (429); null when not rate limited. */
+  /** How long the server asked us to wait (429); null when not rate limited. */
   retryAfterMs: number | null;
 }
 
-/**
- * Parses a `Retry-After` value, which is either delta-seconds or an HTTP-date.
- * Returns milliseconds clamped to [0, MAX_RATE_LIMIT_BACKOFF_MS], or null when unusable.
- */
+/** Parses `Retry-After` (delta-seconds or HTTP-date) to ms, clamped; null when unusable. */
 export function parseRetryAfterMs(value: string | null, now: number = Date.now()): number | null {
   if (!value) {
     return null;
@@ -108,8 +104,8 @@ export function parseRetryAfterMs(value: string | null, now: number = Date.now()
 }
 
 /**
- * Fetches a feed over HTTP with a conditional GET, records status for observability,
- * and parses the body when the response carries one.
+ * Fetches a feed with a conditional GET, records status for observability, and parses
+ * the body when the response carries one.
  */
 export async function fetchFeedWithHttpResult(
   feedUrl: string,
@@ -136,7 +132,7 @@ export async function fetchFeedWithHttpResult(
       });
       const httpStatus = res.status;
       if (httpStatus === 304) {
-        // A 304 body is empty by definition, and may repeat or omit the validators we sent.
+        // A 304 may repeat or omit the validators we sent.
         return {
           entries: [],
           httpStatus,
@@ -248,10 +244,9 @@ export function extractFeedCategories(item: Parser.Item): string[] {
 }
 
 /**
- * Coerces a parsed feed field to a string. rss-parser returns an object for a tag that carries
- * attributes but no text — e.g. `<guid isPermaLink="false"></guid>` becomes
- * `{ $: { isPermaLink: "false" } }` — which is truthy and would otherwise flow into code
- * expecting a string (see truncateToMax in publisher.ts).
+ * Coerces a parsed feed field to a string. rss-parser returns an object for a tag with
+ * attributes but no text — `<guid isPermaLink="false"></guid>` becomes
+ * `{ $: { isPermaLink: "false" } }` — which is truthy and crashes string callers.
  */
 export function toFeedText(value: unknown): string {
   if (typeof value === "string") {

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -43,6 +43,15 @@ const FEED_FETCH_TIMEOUT_MS = 10_000;
 /** Max items to process per feed per poll; limits DoS from huge feeds. */
 export const MAX_ITEMS_PER_POLL = 100;
 
+/** Identifies the fetcher so feed hosts can contact us instead of blocking an anonymous bot. */
+export const FEED_USER_AGENT = "robot.villas RSS poller/1.0 (+https://robot.villas/about)";
+
+/** Backoff used when a 429 arrives without a usable `Retry-After`. */
+export const DEFAULT_RATE_LIMIT_BACKOFF_MS = 60 * 60 * 1000;
+
+/** Ceiling on server-requested backoff, so a bogus `Retry-After` can't park a feed forever. */
+export const MAX_RATE_LIMIT_BACKOFF_MS = 24 * 60 * 60 * 1000;
+
 export interface FeedEntry {
   guid: string;
   title: string;
@@ -52,48 +61,146 @@ export interface FeedEntry {
   feedCategories: string[];
 }
 
+/** Cached HTTP validators for conditional GET, as last seen on a 200 or 304. */
+export interface ConditionalGetState {
+  etag: string | null;
+  lastModified: string | null;
+}
+
 export interface FeedFetchResult {
   entries: FeedEntry[];
   /** HTTP status when a response was received; null on errors before a response (e.g. timeout). */
   httpStatus: number | null;
-  /** Null when the feed was fetched with a 2xx/3xx response and parsed successfully. */
+  /** Null when the feed was fetched with a 2xx/304 response and parsed successfully. */
   errorMessage: string | null;
+  /** True on 304: the feed is unchanged since `validators`, so there is nothing to publish. */
+  notModified: boolean;
+  /**
+   * Validators to persist for the next request. Null means "keep whatever is stored" — an error
+   * response or an unparseable body must not overwrite validators, or the next conditional GET
+   * would get a 304 and we'd never retry the body.
+   */
+  validators: ConditionalGetState | null;
+  /** How long the server asked us to wait before retrying (429); null when not rate limited. */
+  retryAfterMs: number | null;
 }
 
 /**
- * Fetches a feed over HTTP, records status for observability, and parses the body when the response is OK.
+ * Parses a `Retry-After` value, which is either delta-seconds or an HTTP-date.
+ * Returns milliseconds clamped to [0, MAX_RATE_LIMIT_BACKOFF_MS], or null when unusable.
  */
-export async function fetchFeedWithHttpResult(feedUrl: string): Promise<FeedFetchResult> {
+export function parseRetryAfterMs(value: string | null, now: number = Date.now()): number | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  let ms: number;
+  if (/^\d+$/.test(trimmed)) {
+    ms = Number(trimmed) * 1000;
+  } else {
+    const at = Date.parse(trimmed);
+    if (Number.isNaN(at)) {
+      return null;
+    }
+    ms = at - now;
+  }
+  return Math.min(Math.max(ms, 0), MAX_RATE_LIMIT_BACKOFF_MS);
+}
+
+/**
+ * Fetches a feed over HTTP with a conditional GET, records status for observability,
+ * and parses the body when the response carries one.
+ */
+export async function fetchFeedWithHttpResult(
+  feedUrl: string,
+  cached: ConditionalGetState = { etag: null, lastModified: null },
+): Promise<FeedFetchResult> {
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FEED_FETCH_TIMEOUT_MS);
     try {
+      const headers: Record<string, string> = {
+        Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
+        "User-Agent": FEED_USER_AGENT,
+      };
+      if (cached.etag) {
+        headers["If-None-Match"] = cached.etag;
+      }
+      if (cached.lastModified) {
+        headers["If-Modified-Since"] = cached.lastModified;
+      }
       const res = await fetch(feedUrl, {
         signal: controller.signal,
         redirect: "follow",
-        headers: {
-          Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
-          "User-Agent": "robot.villas RSS poller",
-        },
+        headers,
       });
       const httpStatus = res.status;
+      if (httpStatus === 304) {
+        // A 304 body is empty by definition, and may repeat or omit the validators we sent.
+        return {
+          entries: [],
+          httpStatus,
+          errorMessage: null,
+          notModified: true,
+          validators: {
+            etag: res.headers.get("etag") ?? cached.etag,
+            lastModified: res.headers.get("last-modified") ?? cached.lastModified,
+          },
+          retryAfterMs: null,
+        };
+      }
       if (!res.ok) {
-        return { entries: [], httpStatus, errorMessage: `HTTP ${httpStatus}` };
+        const retryAfterMs =
+          httpStatus === 429
+            ? (parseRetryAfterMs(res.headers.get("retry-after")) ?? DEFAULT_RATE_LIMIT_BACKOFF_MS)
+            : null;
+        return {
+          entries: [],
+          httpStatus,
+          errorMessage: `HTTP ${httpStatus}`,
+          notModified: false,
+          validators: null,
+          retryAfterMs,
+        };
       }
       const text = await res.text();
       try {
         const entries = await parseFeedXml(text);
-        return { entries, httpStatus, errorMessage: null };
+        return {
+          entries,
+          httpStatus,
+          errorMessage: null,
+          notModified: false,
+          validators: {
+            etag: res.headers.get("etag"),
+            lastModified: res.headers.get("last-modified"),
+          },
+          retryAfterMs: null,
+        };
       } catch (parseErr) {
         const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
-        return { entries: [], httpStatus, errorMessage: msg };
+        return {
+          entries: [],
+          httpStatus,
+          errorMessage: msg,
+          notModified: false,
+          validators: null,
+          retryAfterMs: null,
+        };
       }
     } finally {
       clearTimeout(timeout);
     }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    return { entries: [], httpStatus: null, errorMessage: msg };
+    return {
+      entries: [],
+      httpStatus: null,
+      errorMessage: msg,
+      notModified: false,
+      validators: null,
+      retryAfterMs: null,
+    };
   }
 }
 
@@ -140,11 +247,35 @@ export function extractFeedCategories(item: Parser.Item): string[] {
   return out;
 }
 
+/**
+ * Coerces a parsed feed field to a string. rss-parser returns an object for a tag that carries
+ * attributes but no text — e.g. `<guid isPermaLink="false"></guid>` becomes
+ * `{ $: { isPermaLink: "false" } }` — which is truthy and would otherwise flow into code
+ * expecting a string (see truncateToMax in publisher.ts).
+ */
+export function toFeedText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    const o = value as Record<string, unknown>;
+    if (typeof o._ === "string") {
+      return o._;
+    }
+    if (typeof o.href === "string") {
+      return o.href;
+    }
+  }
+  return "";
+}
+
 function normalizeFeedItem(item: Parser.Item): FeedEntry {
   const raw = item as Record<string, unknown>;
-  const guid = item.guid || (raw.id as string | undefined) || item.link || item.title || "";
-  const title = normalizeTypography(decodeHtmlEntities(item.title || "(untitled)"));
-  const link = item.link || "";
+  const itemTitle = toFeedText(item.title);
+  const itemLink = toFeedText(item.link);
+  const guid = toFeedText(item.guid) || toFeedText(raw.id) || itemLink || itemTitle || "";
+  const title = normalizeTypography(decodeHtmlEntities(itemTitle || "(untitled)"));
+  const link = itemLink;
   const publishedAt = item.isoDate ? new Date(item.isoDate) : null;
   return { guid, title, link, publishedAt, feedCategories: extractFeedCategories(item) };
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -93,4 +93,10 @@ export const feedPollStatus = pgTable("feed_poll_status", {
   lastHttpStatus: integer("last_http_status"),
   /** Null when the last poll completed successfully at HTTP + parse level. */
   lastError: text("last_error"),
+  /** `ETag` from the last 200/304, sent back as `If-None-Match` for conditional GET. */
+  etag: text("etag"),
+  /** `Last-Modified` from the last 200/304, sent back as `If-Modified-Since`. */
+  lastModified: text("last_modified"),
+  /** Set from a 429 `Retry-After`; the poller skips this feed until it passes. */
+  nextPollAt: timestamp("next_poll_at", { withTimezone: true, mode: "date" }),
 });


### PR DESCRIPTION
Two feeds show no posts, for two unrelated reasons.

**utcc.utoronto.ca (`chris_siebenmann`)** returns 429: "Syndication feed fetchers should not be requesting normal feeds more than once an hour or so, and they should be using properly implemented HTTP Conditional GET."

**undark.org** crashed every poll with `TypeError: e.slice is not a function` — `<guid isPermaLink="false"></guid>` parses to `{ $: { isPermaLink: "false" } }`, a truthy non-string that reached `truncateToMax`.

## Changes

- Poll interval default 5m → 1h, plus a per-feed staleness gate — the interval is process-local, so without it a restart re-fetches all 188 feeds.
- Conditional GET: `feed_poll_status` gains `etag` / `last_modified` / `next_poll_at`; 304 is handled as success with nothing to publish. Validators are stored only after a successful parse and never cleared by an error, so a bad body is retried rather than cached as unchanged.
- 429 backoff: `Retry-After` as delta-seconds or HTTP-date, clamped to 24h, 1h default. A backing-off feed is skipped without overwriting its status row, so /status still shows the 429.
- User-Agent `robot.villas RSS poller/1.0 (+https://robot.villas/about)`, and a new `/about` page it can point at — what the site is, how to add or remove a feed, how the fetcher behaves.
- `toFeedText` coerces guid/title/link, falling back guid → link.

## Needs to land together

Prod sets `POLL_INTERVAL_MS=300000`, which overrides the new default — icco/icco.me#206 raises it.

## Verification

`pnpm lint`, `pnpm test` (132 passed) and `pnpm build` clean. Live check through the real code path: undark returns 200 with 10 entries and an ETag, then 304 on the follow-up; natwelch.com sends no validators and falls back to a plain 200. `/about` rendered against a throwaway Postgres, which also applied migration 0014.

utcc stays empty until it lifts the block on our IP; this makes the fetcher compliant so the block expires.

## Not addressed

No first-poll cap in `publishNewEntries`: undark will publish 10 entries at once, cks up to 100 when it unblocks.