### PR TITLE
chore: remove rachelbythebay feed

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -762,10 +762,6 @@ bots:
     display_name: The Urbanist
     summary: Cities, transportation, housing, and urban policy in the Pacific Northwest.
     profile_photo: https://storage.ghost.io/c/19/31/1931222a-d1c5-42ac-8932-2ee3ac1f8927/content/images/size/w256h256/2026/01/urb-logo.png
-  rachelbythebay:
-    feed_url: https://rachelbythebay.com/w/atom.xml
-    display_name: Rachel by the Bay
-    summary: Systems administration, debugging war stories, distributed systems, and the operational reality of running software.
   schneier:
     feed_url: https://www.schneier.com/feed/atom/
     display_name: Schneier on Security


### PR DESCRIPTION
Feed has been failing to poll. The host is unreachable — it accepts connections but never responds:

- DNS resolves fine (216.218.228.215, Hurricane Electric; AAAA `2001:470:1:954::215`)
- TCP connects on both :80 and :443 — then zero bytes ever come back, on HTTP and HTTPS alike
- ICMP is 100% dropped; `traceroute` dies inside HE after 184.104.188.226
- A fetch from an unrelated network off this LAN also failed to retrieve it (different error shape), so this is unlikely to be local

Removal is not a soft toggle — there's no `enabled` field in the schema, so `sendDeletedBotActivities` will federate a `Delete` for the actor and drop its keypairs. If the site comes back, re-adding creates a fresh actor with new keys and no followers.