### PR TITLE
fix: use PropertyValue attachments for profile fields

### DIFF
--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -25,6 +25,7 @@ import {
   Image,
   Like,
   Note,
+  PropertyValue,
   PUBLIC_COLLECTION,
   type Recipient,
   Reject,
@@ -103,6 +104,11 @@ function buildIcon(photoUrl: string): Image {
   });
 }
 
+/** Profile field values are rendered as HTML, so links need anchors. */
+function link(href: string): string {
+  return `<a href="${escapeHtml(href)}">${escapeHtml(href)}</a>`;
+}
+
 async function buildActor(
   ctx: Context<void>,
   identifier: string,
@@ -127,14 +133,14 @@ async function buildActor(
     endpoints: new Endpoints({
       sharedInbox: ctx.getInboxUri(),
     }),
-    fields: [
-      new Field({
+    attachments: [
+      new PropertyValue({
         name: "source",
-        value: bot.feed_url,
+        value: link(bot.feed_url),
       }),
-      new Field({
+      new PropertyValue({
         name: "old posts",
-        value: profileUrl.href,
+        value: link(profileUrl.href),
       }),
     ],
     url: new URL(`/@${identifier}`, actorUri),

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -105,7 +105,7 @@ function buildIcon(photoUrl: string): Image {
 }
 
 /** Profile field values are rendered as HTML, so links need anchors. */
-function link(href: string): string {
+function buildFieldLink(href: string): string {
   return `<a href="${escapeHtml(href)}">${escapeHtml(href)}</a>`;
 }
 
@@ -136,11 +136,11 @@ async function buildActor(
     attachments: [
       new PropertyValue({
         name: "source",
-        value: link(bot.feed_url),
+        value: buildFieldLink(bot.feed_url),
       }),
       new PropertyValue({
         name: "old posts",
-        value: link(profileUrl.href),
+        value: buildFieldLink(profileUrl.href),
       }),
     ],
     url: new URL(`/@${identifier}`, actorUri),

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -104,9 +104,16 @@ function buildIcon(photoUrl: string): Image {
   });
 }
 
-/** Profile field values are rendered as HTML, so links need anchors. */
+/**
+ * Profile field values are rendered as HTML, so links need anchors.
+ * Anything that isn't an http(s) URL stays plain text.
+ */
 function buildFieldLink(href: string): string {
-  return `<a href="${escapeHtml(href)}">${escapeHtml(href)}</a>`;
+  const url = safeParseUrl(href);
+  if (!url) {
+    return escapeHtml(href);
+  }
+  return `<a href="${escapeHtml(url.href)}">${escapeHtml(url.href)}</a>`;
 }
 
 async function buildActor(


### PR DESCRIPTION
`main` build is red: `16ce9b6` added `fields: [new Field(...)]` to the actor, but Fedify has no `Field` class — Mastodon-style profile fields are `attachments` of `PropertyValue`.

Swaps to `attachments` + `PropertyValue`, wrapping each value in an anchor since field values render as HTML.

`pnpm lint`, `pnpm build`, `pnpm test` all pass locally.