### PR TITLE
feat: poll feeds every 15 minutes, drop POLL_INTERVAL_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ The `relays` list contains ActivityPub relay actor URLs. The server subscribes t
 | `DATABASE_URL`      | PostgreSQL connection string                     | (required)         |
 | `DOMAIN`            | Public domain for ActivityPub IDs and WebFinger  | (required)         |
 | `PORT`              | HTTP server port                                 | `3000`             |
-| `POLL_INTERVAL_MS`  | Milliseconds between RSS poll cycles             | `3600000` (1 hour) |
+| `POLL_INTERVAL_MS`  | Milliseconds between RSS poll cycles             | `900000` (15 min)  |
 | `BLOCKED_INSTANCES` | Comma-separated hostnames to reject Follows from | (none)             |
 | `GEMINI_API_KEY`    | Google Gemini API key for AI hashtag suggestions | (none)             |
 | `GEMINI_PROJECT`    | GCP project for Vertex AI (alternative to key)   | (none)             |
 | `GEMINI_LOCATION`   | GCP region for Vertex AI                         | `us-central1`     |
 | `GEMINI_MODEL`      | Gemini model name                                | `gemini-2.5-flash` |
 
-The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Don't set `POLL_INTERVAL_MS` below an hour — feed hosts block fetchers that poll faster.
+The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Lower `POLL_INTERVAL_MS` with care — it is a floor, not a promise, and a host that wants to be polled less often enforces that itself with a 429.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The `relays` list contains ActivityPub relay actor URLs. The server subscribes t
 | `GEMINI_LOCATION`   | GCP region for Vertex AI                         | `us-central1`     |
 | `GEMINI_MODEL`      | Gemini model name                                | `gemini-2.5-flash` |
 
-The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Feeds are polled at most once every 15 minutes; the interval is a floor rather than a promise, and it is a constant (`DEFAULT_INTERVAL_MS` in `src/lib/poller.ts`), not a config knob — a host that wants to be polled less often enforces that itself with a 429.
+The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Feeds are fetched at most once every 15 minutes — a constant (`DEFAULT_INTERVAL_MS` in `src/lib/poller.ts`), not a config knob.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,13 @@ The `relays` list contains ActivityPub relay actor URLs. The server subscribes t
 | `DATABASE_URL`      | PostgreSQL connection string                     | (required)         |
 | `DOMAIN`            | Public domain for ActivityPub IDs and WebFinger  | (required)         |
 | `PORT`              | HTTP server port                                 | `3000`             |
-| `POLL_INTERVAL_MS`  | Milliseconds between RSS poll cycles             | `900000` (15 min)  |
 | `BLOCKED_INSTANCES` | Comma-separated hostnames to reject Follows from | (none)             |
 | `GEMINI_API_KEY`    | Google Gemini API key for AI hashtag suggestions | (none)             |
 | `GEMINI_PROJECT`    | GCP project for Vertex AI (alternative to key)   | (none)             |
 | `GEMINI_LOCATION`   | GCP region for Vertex AI                         | `us-central1`     |
 | `GEMINI_MODEL`      | Gemini model name                                | `gemini-2.5-flash` |
 
-The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Lower `POLL_INTERVAL_MS` with care — it is a floor, not a promise, and a host that wants to be polled less often enforces that itself with a 429.
+The poller identifies itself with a `robot.villas` User-Agent, sends conditional GETs (`If-None-Match` / `If-Modified-Since`) so unchanged feeds cost a 304, and stops polling a feed until the `Retry-After` of a 429 has elapsed. Feeds are polled at most once every 15 minutes; the interval is a floor rather than a promise, and it is a constant (`DEFAULT_INTERVAL_MS` in `src/lib/poller.ts`), not a config knob — a host that wants to be polled less often enforces that itself with a 429.
 
 ## Development
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -94,7 +94,7 @@ export default function AboutPage() {
           <li>
             It identifies itself as <Code>{FEED_USER_AGENT}</Code>.
           </li>
-          <li>Each feed is fetched at most once an hour.</li>
+          <li>Each feed is fetched at most once every 15 minutes.</li>
           <li>
             Requests are conditional (<Code>If-None-Match</Code> / <Code>If-Modified-Since</Code>),
             so an unchanged feed costs you a 304 and no body.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -60,15 +60,12 @@ export async function register() {
 
   const { startPoller } = await import("@/lib/poller");
   const { parsePositiveInt } = await import("@/lib/env");
-  // Fifteen minutes; hosts that want slower get it via their own 429 backoff.
-  const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 900_000);
   const pollConcurrency = parsePositiveInt(process.env.POLL_CONCURRENCY, 10);
 
   startPoller({
     config,
     db,
     domain,
-    intervalMs: pollIntervalMs,
     concurrency: pollConcurrency,
     getContext: () => federation.createContext(new URL(`https://${domain}`)),
   });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -60,8 +60,8 @@ export async function register() {
 
   const { startPoller } = await import("@/lib/poller");
   const { parsePositiveInt } = await import("@/lib/env");
-  // One hour: feed hosts 429 fetchers that poll faster.
-  const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 3_600_000);
+  // Fifteen minutes; hosts that want slower get it via their own 429 backoff.
+  const pollIntervalMs = parsePositiveInt(process.env.POLL_INTERVAL_MS, 900_000);
   const pollConcurrency = parsePositiveInt(process.env.POLL_CONCURRENCY, 10);
 
   startPoller({

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -19,6 +19,7 @@ export interface PollerOptions {
   config: FeedsConfig;
   db: Db;
   domain: string;
+  /** Overridden by tests only; production always uses DEFAULT_INTERVAL_MS. */
   intervalMs?: number;
   concurrency?: number;
   getContext: () => Context<void>;

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -7,8 +7,9 @@ import { parsePositiveInt } from "./env";
 import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
-/** Feed hosts 429 fetchers that poll faster than hourly. */
-const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+/** Conditional GETs keep unchanged feeds at a 304, and a 429 backs that feed
+ * off on its own, so a 15 minute cycle is safe. */
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
 /** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
  * poll cycle run far longer than intervalMs when polled fully sequentially. */
 const DEFAULT_CONCURRENCY = 10;

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -7,8 +7,7 @@ import { parsePositiveInt } from "./env";
 import { fetchFeedWithHttpResult } from "./rss";
 import { publishNewEntries } from "./publisher";
 
-/** Conditional GETs keep unchanged feeds at a 304, and a 429 backs that feed
- * off on its own, so a 15 minute cycle is safe. */
+/** Not configurable: a 429 backs a slow-polling host off on its own. */
 const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
 /** How many bot feeds to poll at once. Keeps a large feeds.yml from making a
  * poll cycle run far longer than intervalMs when polled fully sequentially. */
@@ -19,7 +18,7 @@ export interface PollerOptions {
   config: FeedsConfig;
   db: Db;
   domain: string;
-  /** Overridden by tests only; production always uses DEFAULT_INTERVAL_MS. */
+  /** Tests only. */
   intervalMs?: number;
   concurrency?: number;
   getContext: () => Context<void>;


### PR DESCRIPTION
Polls every 15 minutes instead of hourly, as a constant (`DEFAULT_INTERVAL_MS`) rather than a config knob — `POLL_INTERVAL_MS` is gone. No compose change needed; #206 already removed the override.

Reverses #206's interval, which went hourly for utcc.utoronto.ca's 429. Still fine: a 429 sets that feed's `nextPollAt` from `Retry-After`, so utcc stays hourly on its own.