### PR TITLE
fix: let stuck relay and follow subscriptions self-heal

### DIFF
--- a/drizzle/0015_bitter_human_robot.sql
+++ b/drizzle/0015_bitter_human_robot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "following" ADD COLUMN "status_changed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "relays" ADD COLUMN "status_changed_at" timestamp with time zone;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,525 @@
+{
+  "id": "a1133ea8-62ed-40a9-ab29-a3b503ad3822",
+  "prevId": "60e14d4d-ba10-4415-81be-8e3f3676ba79",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor_keypairs": {
+      "name": "actor_keypairs",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_entries": {
+      "name": "feed_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feed_entries_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "boost_count": {
+          "name": "boost_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hashtags": {
+          "name": "hashtags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feed_entries_hashtags_gin_idx": {
+          "name": "feed_entries_hashtags_gin_idx",
+          "columns": [
+            {
+              "expression": "hashtags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "feed_entries_published_at_idx": {
+          "name": "feed_entries_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"feed_entries\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feed_entries_bot_username_guid_unique": {
+          "name": "feed_entries_bot_username_guid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "guid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_poll_status": {
+      "name": "feed_poll_status",
+      "schema": "",
+      "columns": {
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_poll_at": {
+          "name": "next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followers": {
+      "name": "followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_id": {
+          "name": "follow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followers_bot_username_follower_id_unique": {
+          "name": "followers_bot_username_follower_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "follower_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.following": {
+      "name": "following",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "following_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_actor_id": {
+          "name": "target_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "following_bot_username_handle_unique": {
+          "name": "following_bot_username_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relays": {
+      "name": "relays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "relays_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "relay_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_activity_id": {
+          "name": "follow_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "relays_bot_username_url_unique": {
+          "name": "relays_bot_username_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bot_username",
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.relay_status": {
+      "name": "relay_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1786741789774,
       "tag": "0014_cloudy_miek",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786922617878,
+      "tag": "0015_bitter_human_robot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -14,6 +14,9 @@ import {
   removeFollower,
   getKeypairs,
   saveKeypairs,
+  upsertFollowing,
+  markFollowingAccepted,
+  getAllFollowing,
   type Db,
 } from "../db";
 import * as schema from "../schema";
@@ -29,6 +32,7 @@ async function cleanTestData(db: Db) {
   await db.delete(schema.actorKeypairs).where(inArray(schema.actorKeypairs.botUsername, TEST_BOTS));
   await db.delete(schema.followers).where(inArray(schema.followers.botUsername, TEST_BOTS));
   await db.delete(schema.feedPollStatus).where(inArray(schema.feedPollStatus.botUsername, TEST_BOTS));
+  await db.delete(schema.following).where(inArray(schema.following.botUsername, TEST_BOTS));
 }
 
 describeWithDb("database", () => {
@@ -282,6 +286,56 @@ describeWithDb("database", () => {
       const kps = await getKeypairs(db, "legacybot");
       expect(kps).toHaveLength(1);
       expect(kps![0].publicKey).toMatchObject({ kty: "RSA", n: "legacy" });
+    });
+  });
+
+  describe("following", () => {
+    const HANDLE = "_followback@example.test";
+
+    async function seedPending(bots: string[]) {
+      for (const botUsername of bots) {
+        await upsertFollowing(db, botUsername, HANDLE, "https://example.test/user/_followback", `https://robot.test/users/${botUsername}/follows/1`);
+      }
+    }
+
+    it("markFollowingAccepted flips only the named bots", async () => {
+      await seedPending(["bot_a", "bot_b"]);
+
+      await markFollowingAccepted(db, HANDLE, ["bot_a"]);
+
+      const rows = await getAllFollowing(db);
+      const byBot = new Map(rows.filter((r) => r.handle === HANDLE).map((r) => [r.botUsername, r.status]));
+      expect(byBot.get("bot_a")).toBe("accepted");
+      expect(byBot.get("bot_b")).toBe("pending");
+    });
+
+    it("markFollowingAccepted records when the status changed", async () => {
+      await seedPending(["bot_a"]);
+      await markFollowingAccepted(db, HANDLE, ["bot_a"]);
+
+      const [row] = await db
+        .select({ statusChangedAt: schema.following.statusChangedAt })
+        .from(schema.following)
+        .where(inArray(schema.following.botUsername, ["bot_a"]));
+      expect(row.statusChangedAt).toBeInstanceOf(Date);
+    });
+
+    it("markFollowingAccepted is a no-op for an empty bot list", async () => {
+      await seedPending(["bot_a"]);
+      await markFollowingAccepted(db, HANDLE, []);
+
+      const rows = await getAllFollowing(db);
+      expect(rows.find((r) => r.botUsername === "bot_a")?.status).toBe("pending");
+    });
+
+    it("markFollowingAccepted does not touch other handles", async () => {
+      await upsertFollowing(db, "bot_a", "someone@example.test", "https://example.test/user/someone", "https://robot.test/f/2");
+      await seedPending(["bot_a"]);
+
+      await markFollowingAccepted(db, HANDLE, ["bot_a"]);
+
+      const rows = await getAllFollowing(db);
+      expect(rows.find((r) => r.handle === "someone@example.test")?.status).toBe("pending");
     });
   });
 });

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -17,6 +17,10 @@ import {
   upsertFollowing,
   markFollowingAccepted,
   getAllFollowing,
+  updateFollowingStatus,
+  upsertRelay,
+  updateRelayStatus,
+  getAllRelays,
   type Db,
 } from "../db";
 import * as schema from "../schema";
@@ -33,6 +37,7 @@ async function cleanTestData(db: Db) {
   await db.delete(schema.followers).where(inArray(schema.followers.botUsername, TEST_BOTS));
   await db.delete(schema.feedPollStatus).where(inArray(schema.feedPollStatus.botUsername, TEST_BOTS));
   await db.delete(schema.following).where(inArray(schema.following.botUsername, TEST_BOTS));
+  await db.delete(schema.relays).where(inArray(schema.relays.botUsername, TEST_BOTS));
 }
 
 describeWithDb("database", () => {
@@ -328,6 +333,17 @@ describeWithDb("database", () => {
       expect(rows.find((r) => r.botUsername === "bot_a")?.status).toBe("pending");
     });
 
+    it("markFollowingAccepted leaves an explicit Reject alone", async () => {
+      // The pending set is a snapshot; a Reject can land before we write.
+      await seedPending(["bot_a"]);
+      await updateFollowingStatus(db, "https://robot.test/users/bot_a/follows/1", "rejected");
+
+      await markFollowingAccepted(db, HANDLE, ["bot_a"]);
+
+      const rows = await getAllFollowing(db);
+      expect(rows.find((r) => r.botUsername === "bot_a")?.status).toBe("rejected");
+    });
+
     it("markFollowingAccepted does not touch other handles", async () => {
       await upsertFollowing(db, "bot_a", "someone@example.test", "https://example.test/user/someone", "https://robot.test/f/2");
       await seedPending(["bot_a"]);
@@ -336,6 +352,52 @@ describeWithDb("database", () => {
 
       const rows = await getAllFollowing(db);
       expect(rows.find((r) => r.handle === "someone@example.test")?.status).toBe("pending");
+    });
+  });
+
+  describe("relays", () => {
+    const URL = "https://relay.example.test/actor";
+    const seed = () =>
+      upsertRelay(db, "bot_a", URL, `${URL.replace("/actor", "/inbox")}`, URL, "https://robot.test/f/relay-1");
+
+    const relayRow = async () => (await getAllRelays(db, "bot_a")).find((r) => r.url === URL);
+
+    it("upsertRelay does not restamp a row that is already pending", async () => {
+      // Otherwise a permanently-pending relay looks freshly changed on every
+      // boot, hiding exactly the stuck state the column exists to surface.
+      await seed();
+      const first = (await relayRow())!.statusChangedAt;
+      expect(first).toBeInstanceOf(Date);
+
+      await seed();
+      expect((await relayRow())!.statusChangedAt?.getTime()).toBe(first!.getTime());
+    });
+
+    it("upsertRelay restamps when reviving a rejected row", async () => {
+      await seed();
+      await updateRelayStatus(db, "https://robot.test/f/relay-1", "rejected");
+      const rejectedAt = (await relayRow())!.statusChangedAt!;
+      await db
+        .update(schema.relays)
+        .set({ statusChangedAt: new Date(rejectedAt.getTime() - 60_000) })
+        .where(inArray(schema.relays.botUsername, ["bot_a"]));
+
+      await seed();
+
+      const row = (await relayRow())!;
+      expect(row.status).toBe("pending");
+      expect(row.statusChangedAt!.getTime()).toBeGreaterThan(rejectedAt.getTime() - 60_000);
+    });
+
+    it("upsertRelay backfills a null timestamp on a pending row", async () => {
+      await seed();
+      await db
+        .update(schema.relays)
+        .set({ statusChangedAt: null })
+        .where(inArray(schema.relays.botUsername, ["bot_a"]));
+
+      await seed();
+      expect((await relayRow())!.statusChangedAt).toBeInstanceOf(Date);
     });
   });
 });

--- a/src/lib/__tests__/subscriptions.test.ts
+++ b/src/lib/__tests__/subscriptions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  RELAY_REJECT_RETRY_MS,
+  isRelayTerminal,
+  findLostAccepts,
+} from "../subscriptions";
+
+const NOW = new Date("2026-08-16T00:00:00Z");
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+describe("isRelayTerminal", () => {
+  it("treats accepted as permanently terminal", () => {
+    expect(isRelayTerminal("accepted", daysAgo(9999), NOW)).toBe(true);
+    expect(isRelayTerminal("accepted", null, NOW)).toBe(true);
+  });
+
+  it("never treats pending as terminal", () => {
+    expect(isRelayTerminal("pending", daysAgo(1), NOW)).toBe(false);
+    expect(isRelayTerminal("pending", null, NOW)).toBe(false);
+  });
+
+  it("honors a recent rejection", () => {
+    expect(isRelayTerminal("rejected", daysAgo(1), NOW)).toBe(true);
+    expect(isRelayTerminal("rejected", daysAgo(29), NOW)).toBe(true);
+  });
+
+  it("expires a rejection once the cooldown passes", () => {
+    expect(isRelayTerminal("rejected", daysAgo(31), NOW)).toBe(false);
+    expect(isRelayTerminal("rejected", daysAgo(120), NOW)).toBe(false);
+  });
+
+  it("re-asks when the rejection has no recorded time", () => {
+    // Rows rejected before status_changed_at existed have an unknown age. Ask
+    // once; the reply stamps the column and starts the cooldown properly.
+    expect(isRelayTerminal("rejected", null, NOW)).toBe(false);
+  });
+
+  it("uses the configured cooldown", () => {
+    expect(isRelayTerminal("rejected", daysAgo(2), NOW, 24 * 60 * 60 * 1000)).toBe(false);
+    expect(RELAY_REJECT_RETRY_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe("findLostAccepts", () => {
+  const pending = [
+    { botUsername: "import_ai", actorId: "https://robot.villas/users/import_ai" },
+    { botUsername: "hell_gate", actorId: "https://robot.villas/users/hell_gate" },
+    { botUsername: "danluu", actorId: "https://robot.villas/users/danluu" },
+  ];
+
+  it("returns bots the target already lists as followers", () => {
+    const followers = new Set([
+      "https://robot.villas/users/import_ai",
+      "https://robot.villas/users/hell_gate",
+      "https://example.com/users/someone",
+    ]);
+    expect(findLostAccepts(pending, followers).sort()).toEqual(["hell_gate", "import_ai"]);
+  });
+
+  it("returns nothing when the target lists none of them", () => {
+    expect(findLostAccepts(pending, new Set(["https://example.com/users/x"]))).toEqual([]);
+  });
+
+  it("returns nothing for an empty followers collection", () => {
+    // An actor that hides its followers must not be read as "no follow exists";
+    // the caller falls back to re-sending the Follow.
+    expect(findLostAccepts(pending, new Set())).toEqual([]);
+  });
+
+  it("ignores a trailing slash difference", () => {
+    const followers = new Set(["https://robot.villas/users/danluu/"]);
+    expect(findLostAccepts(pending, followers)).toEqual(["danluu"]);
+  });
+
+  it("skips rows with no resolved actor id", () => {
+    const rows = [{ botUsername: "ghost", actorId: null }];
+    expect(findLostAccepts(rows, new Set(["https://robot.villas/users/ghost"]))).toEqual([]);
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -783,10 +783,23 @@ export async function upsertFollowing(
 ): Promise<void> {
   await db
     .insert(schema.following)
-    .values({ botUsername, handle, targetActorId, followActivityId, status: "pending" })
+    .values({
+      botUsername,
+      handle,
+      targetActorId,
+      followActivityId,
+      status: "pending",
+      statusChangedAt: new Date(),
+    })
     .onConflictDoUpdate({
       target: [schema.following.botUsername, schema.following.handle],
-      set: { targetActorId, followActivityId, status: "pending", deletedAt: null },
+      set: {
+        targetActorId,
+        followActivityId,
+        status: "pending",
+        statusChangedAt: new Date(),
+        deletedAt: null,
+      },
     });
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -653,7 +653,11 @@ export async function upsertRelay(
         actorId,
         followActivityId,
         status: "pending" as const,
-        statusChangedAt: new Date(),
+        // Only a real transition restamps, so a permanently-pending relay
+        // doesn't look freshly changed on every boot.
+        statusChangedAt: sql`CASE WHEN ${schema.relays.status} = 'pending'
+          AND ${schema.relays.statusChangedAt} IS NOT NULL
+          THEN ${schema.relays.statusChangedAt} ELSE now() END`,
         deletedAt: null,
       },
     });
@@ -797,7 +801,10 @@ export async function upsertFollowing(
         targetActorId,
         followActivityId,
         status: "pending",
-        statusChangedAt: new Date(),
+        // See upsertRelay: retries must not restamp an unchanged status.
+        statusChangedAt: sql`CASE WHEN ${schema.following.status} = 'pending'
+          AND ${schema.following.statusChangedAt} IS NOT NULL
+          THEN ${schema.following.statusChangedAt} ELSE now() END`,
         deletedAt: null,
       },
     });
@@ -830,6 +837,9 @@ export async function markFollowingAccepted(
       and(
         eq(schema.following.handle, handle),
         inArray(schema.following.botUsername, botUsernames),
+        // The caller's pending set is a snapshot; don't clobber a Reject that
+        // landed since.
+        eq(schema.following.status, "pending"),
         isNull(schema.following.deletedAt),
       )!,
     );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -814,12 +814,7 @@ export async function updateFollowingStatus(
     .where(eq(schema.following.followActivityId, followActivityId));
 }
 
-/**
- * Marks follows accepted for a set of bots that the target already lists as
- * followers — an `Accept` that was delivered but never matched a row. See
- * `findLostAccepts`; the target will not re-Accept a duplicate Follow, so
- * without this the rows stay pending forever.
- */
+/** Records follows the target already lists as followers. See `findLostAccepts`. */
 export async function markFollowingAccepted(
   db: Db,
   handle: string,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -575,6 +575,7 @@ export interface RelayRow {
   inboxUrl: string | null;
   actorId: string | null;
   status: "pending" | "accepted" | "rejected";
+  statusChangedAt: Date | null;
   followActivityId: string | null;
 }
 
@@ -587,6 +588,7 @@ export async function getAcceptedRelays(db: Db): Promise<RelayRow[]> {
       inboxUrl: schema.relays.inboxUrl,
       actorId: schema.relays.actorId,
       status: schema.relays.status,
+      statusChangedAt: schema.relays.statusChangedAt,
       followActivityId: schema.relays.followActivityId,
     })
     .from(schema.relays)
@@ -618,6 +620,7 @@ export async function getAllRelays(db: Db, botUsername?: string): Promise<RelayR
       inboxUrl: schema.relays.inboxUrl,
       actorId: schema.relays.actorId,
       status: schema.relays.status,
+      statusChangedAt: schema.relays.statusChangedAt,
       followActivityId: schema.relays.followActivityId,
     })
     .from(schema.relays)
@@ -634,10 +637,25 @@ export async function upsertRelay(
 ): Promise<void> {
   await db
     .insert(schema.relays)
-    .values({ botUsername, url, inboxUrl, actorId, followActivityId, status: "pending" })
+    .values({
+      botUsername,
+      url,
+      inboxUrl,
+      actorId,
+      followActivityId,
+      status: "pending",
+      statusChangedAt: new Date(),
+    })
     .onConflictDoUpdate({
       target: [schema.relays.botUsername, schema.relays.url],
-      set: { inboxUrl, actorId, followActivityId, status: "pending" as const, deletedAt: null },
+      set: {
+        inboxUrl,
+        actorId,
+        followActivityId,
+        status: "pending" as const,
+        statusChangedAt: new Date(),
+        deletedAt: null,
+      },
     });
 }
 
@@ -650,6 +668,7 @@ export async function getRelayByActivityId(db: Db, followActivityId: string): Pr
       inboxUrl: schema.relays.inboxUrl,
       actorId: schema.relays.actorId,
       status: schema.relays.status,
+      statusChangedAt: schema.relays.statusChangedAt,
       followActivityId: schema.relays.followActivityId,
     })
     .from(schema.relays)
@@ -665,7 +684,7 @@ export async function updateRelayStatus(
 ): Promise<void> {
   await db
     .update(schema.relays)
-    .set({ status })
+    .set({ status, statusChangedAt: new Date() })
     .where(eq(schema.relays.followActivityId, followActivityId));
 }
 
@@ -778,8 +797,34 @@ export async function updateFollowingStatus(
 ): Promise<void> {
   await db
     .update(schema.following)
-    .set({ status })
+    .set({ status, statusChangedAt: new Date() })
     .where(eq(schema.following.followActivityId, followActivityId));
+}
+
+/**
+ * Marks follows accepted for a set of bots that the target already lists as
+ * followers — an `Accept` that was delivered but never matched a row. See
+ * `findLostAccepts`; the target will not re-Accept a duplicate Follow, so
+ * without this the rows stay pending forever.
+ */
+export async function markFollowingAccepted(
+  db: Db,
+  handle: string,
+  botUsernames: string[],
+): Promise<void> {
+  if (botUsernames.length === 0) {
+    return;
+  }
+  await db
+    .update(schema.following)
+    .set({ status: "accepted", statusChangedAt: new Date() })
+    .where(
+      and(
+        eq(schema.following.handle, handle),
+        inArray(schema.following.botUsername, botUsernames),
+        isNull(schema.following.deletedAt),
+      )!,
+    );
 }
 
 export async function getFollowingByActivityId(

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -13,16 +13,19 @@ import { getLogger } from "@logtape/logtape";
 import { Temporal as TemporalPolyfill } from "@js-temporal/polyfill";
 import {
   Accept,
+  type Actor,
   Add,
   Announce,
   Application,
   Create,
   Delete,
+  type DocumentLoader,
   EmojiReact,
   Endpoints,
   Follow,
   Hashtag,
   Image,
+  isActor,
   Like,
   Note,
   PropertyValue,
@@ -34,6 +37,7 @@ import {
 } from "@fedify/vocab";
 import escapeHtml from "escape-html";
 import { getRelaySubscriptionBot, type BotConfig, type FeedsConfig } from "./config";
+import { findLostAccepts, isRelayTerminal } from "./subscriptions";
 import {
   addFollower,
   countEntries,
@@ -55,6 +59,7 @@ import {
   getRelayByActivityId,
   getKeypairs,
   incrementBoostCount,
+  markFollowingAccepted,
   incrementLikeCount,
   pruneRedundantRelaySubscriptions,
   removeAllEntries,
@@ -726,6 +731,50 @@ export async function sendProfileUpdates(
   }
 }
 
+/** Cap on follower entries read per target; some collections are enormous. */
+const FOLLOWER_SCAN_LIMIT = 20_000;
+
+/**
+ * Collects the actor IDs listed in a target's followers collection.
+ *
+ * Best-effort: an actor that hides its followers, or a fetch that fails, yields
+ * an empty (or partial) set. Callers must read that as "unknown", never as "not
+ * a follower" — a missing ID only ever means we fall back to re-sending the
+ * Follow, which is the safe direction.
+ */
+async function fetchFollowerActorIds(
+  ctx: Context<void>,
+  actor: Actor,
+  documentLoader: DocumentLoader,
+  handle: string,
+): Promise<Set<string>> {
+  const ids = new Set<string>();
+  try {
+    const collection = await actor.getFollowers({ documentLoader, suppressError: true });
+    if (!collection) {
+      logger.debug("No readable followers collection for {handle}", { handle });
+      return ids;
+    }
+    for await (const item of ctx.traverseCollection(collection, { documentLoader })) {
+      const id = item.id?.href;
+      if (id) {
+        ids.add(id);
+      }
+      if (ids.size >= FOLLOWER_SCAN_LIMIT) {
+        logger.warn("Stopped reading {handle} followers at the {limit} entry cap", {
+          handle,
+          limit: FOLLOWER_SCAN_LIMIT,
+        });
+        break;
+      }
+    }
+  } catch (error) {
+    // Keep whatever was collected; a partial set can only produce true matches.
+    logger.warn("Could not read followers of {handle}: {error}", { handle, error });
+  }
+  return ids;
+}
+
 /**
  * Sends a Follow activity from every bot to each account listed in
  * config.follows. Skips accounts that a bot has already followed.
@@ -760,6 +809,7 @@ export async function followAccounts(
     const handle = rawHandle.replace(/^@/, "");
 
     let targetActor: Recipient;
+    let resolvedObject: unknown;
     try {
       const resolved = await ctx.lookupObject(`acct:${handle}`, {
         documentLoader,
@@ -771,6 +821,7 @@ export async function followAccounts(
         );
         continue;
       }
+      resolvedObject = resolved;
       targetActor = resolved as Recipient;
       if (!targetActor.id || !targetActor.inboxId) {
         logger.error("Actor for {handle} has no id or inbox", { handle });
@@ -779,6 +830,34 @@ export async function followAccounts(
     } catch (error) {
       logger.error("Failed to look up {handle}: {error}", { handle, error });
       continue;
+    }
+
+    // Reconcile before re-sending: a Follow whose Accept was delivered but
+    // never matched a row stays pending forever, because the target will not
+    // re-Accept a duplicate Follow. If the target already lists the bot as a
+    // follower, record that instead of sending another Follow into the void.
+    const pendingForHandle = existing.filter(
+      (f) => f.handle === handle && f.status === "pending",
+    );
+    if (pendingForHandle.length > 0 && isActor(resolvedObject)) {
+      const followerIds = await fetchFollowerActorIds(ctx, resolvedObject, documentLoader, handle);
+      const reconciled = findLostAccepts(
+        pendingForHandle.map((f) => ({
+          botUsername: f.botUsername,
+          actorId: ctx.getActorUri(f.botUsername).href,
+        })),
+        followerIds,
+      );
+      if (reconciled.length > 0) {
+        await markFollowingAccepted(db, handle, reconciled);
+        for (const bot of reconciled) {
+          existingSet.add(`${bot}:${handle}`);
+        }
+        logger.info(
+          "Reconciled {count} lost Accept(s) for {handle}: {bots} already follow it",
+          { count: reconciled.length, handle, bots: reconciled.join(", ") },
+        );
+      }
     }
 
     for (const botUsername of botUsernames) {
@@ -891,13 +970,17 @@ export async function subscribeToRelays(
 
   const hasAcceptedForInstance = (url: string) =>
     allRelays.some((r) => r.url === url && r.status === "accepted");
-  // Terminal (accepted or rejected) for the designated bot + URL — pending retries.
+  // Terminal for the designated bot + URL. `accepted` is permanent; a Reject
+  // expires after RELAY_REJECT_RETRY_MS so a relay that denied us under a
+  // subscription format we have since fixed gets asked again rather than
+  // staying frozen forever. Pending always retries.
+  const now = new Date();
   const designatedTerminalUrls = new Set(
     allRelays
       .filter(
         (r) =>
           r.botUsername === designated &&
-          (r.status === "accepted" || r.status === "rejected"),
+          isRelayTerminal(r.status, r.statusChangedAt, now),
       )
       .map((r) => r.url),
   );

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -731,42 +731,55 @@ export async function sendProfileUpdates(
   }
 }
 
-/** Cap on follower entries read per target; some collections are enormous. */
+/** Caps on how much of a followers collection we read; some are enormous. */
 const FOLLOWER_SCAN_LIMIT = 20_000;
+const FOLLOWER_PAGE_LIMIT = 200;
 
 /**
  * Collects the actor IDs listed in a target's followers collection.
  *
+ * Walks pages reading `itemIds` rather than using `traverseCollection`, which
+ * dereferences every entry — that costs one HTTP request per follower and
+ * aborts the whole traversal when any one of them 404s (tags.pub still lists
+ * bots we have since removed). We only need the IDs.
+ *
  * Best-effort: an actor that hides its followers, or a fetch that fails, yields
- * an empty (or partial) set. Callers must read that as "unknown", never as "not
- * a follower" — a missing ID only ever means we fall back to re-sending the
+ * an empty or partial set. Callers must read that as "unknown", never as "not a
+ * follower" — a missing ID only ever means we fall back to re-sending the
  * Follow, which is the safe direction.
  */
 async function fetchFollowerActorIds(
-  ctx: Context<void>,
   actor: Actor,
   documentLoader: DocumentLoader,
   handle: string,
 ): Promise<Set<string>> {
   const ids = new Set<string>();
+  const opts = { documentLoader, suppressError: true } as const;
   try {
-    const collection = await actor.getFollowers({ documentLoader, suppressError: true });
+    const collection = await actor.getFollowers(opts);
     if (!collection) {
       logger.debug("No readable followers collection for {handle}", { handle });
       return ids;
     }
-    for await (const item of ctx.traverseCollection(collection, { documentLoader })) {
-      const id = item.id?.href;
-      if (id) {
-        ids.add(id);
+    // Small collections inline their items instead of paginating.
+    for (const id of collection.itemIds) {
+      ids.add(id.href);
+    }
+    let page = await collection.getFirst(opts);
+    let pageCount = 0;
+    while (page !== null) {
+      for (const id of page.itemIds) {
+        ids.add(id.href);
       }
-      if (ids.size >= FOLLOWER_SCAN_LIMIT) {
-        logger.warn("Stopped reading {handle} followers at the {limit} entry cap", {
+      if (ids.size >= FOLLOWER_SCAN_LIMIT || ++pageCount >= FOLLOWER_PAGE_LIMIT) {
+        logger.warn("Stopped reading {handle} followers at {ids} ids / {pages} pages", {
           handle,
-          limit: FOLLOWER_SCAN_LIMIT,
+          ids: ids.size,
+          pages: pageCount,
         });
         break;
       }
+      page = await page.getNext(opts);
     }
   } catch (error) {
     // Keep whatever was collected; a partial set can only produce true matches.
@@ -840,7 +853,7 @@ export async function followAccounts(
       (f) => f.handle === handle && f.status === "pending",
     );
     if (pendingForHandle.length > 0 && isActor(resolvedObject)) {
-      const followerIds = await fetchFollowerActorIds(ctx, resolvedObject, documentLoader, handle);
+      const followerIds = await fetchFollowerActorIds(resolvedObject, documentLoader, handle);
       const reconciled = findLostAccepts(
         pendingForHandle.map((f) => ({
           botUsername: f.botUsername,

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -736,17 +736,15 @@ const FOLLOWER_SCAN_LIMIT = 20_000;
 const FOLLOWER_PAGE_LIMIT = 200;
 
 /**
- * Collects the actor IDs listed in a target's followers collection.
+ * Actor IDs in a target's followers collection.
  *
- * Walks pages reading `itemIds` rather than using `traverseCollection`, which
- * dereferences every entry — that costs one HTTP request per follower and
- * aborts the whole traversal when any one of them 404s (tags.pub still lists
- * bots we have since removed). We only need the IDs.
+ * Pages over `itemIds` rather than `traverseCollection`, which dereferences
+ * every entry — one request per follower, and it throws if any 404s (tags.pub
+ * still lists bots we removed).
  *
- * Best-effort: an actor that hides its followers, or a fetch that fails, yields
- * an empty or partial set. Callers must read that as "unknown", never as "not a
- * follower" — a missing ID only ever means we fall back to re-sending the
- * Follow, which is the safe direction.
+ * Best-effort: hidden followers or a failed fetch yield an empty or partial
+ * set. Read that as "unknown", never "not a follower" — a missing ID only means
+ * we fall back to re-sending, which is the safe direction.
  */
 async function fetchFollowerActorIds(
   actor: Actor,
@@ -845,10 +843,9 @@ export async function followAccounts(
       continue;
     }
 
-    // Reconcile before re-sending: a Follow whose Accept was delivered but
-    // never matched a row stays pending forever, because the target will not
-    // re-Accept a duplicate Follow. If the target already lists the bot as a
-    // follower, record that instead of sending another Follow into the void.
+    // A Follow whose Accept was delivered but never matched a row stays pending
+    // forever, since the target won't re-Accept a duplicate. Record what the
+    // target already lists instead of sending another Follow into the void.
     const pendingForHandle = existing.filter(
       (f) => f.handle === handle && f.status === "pending",
     );
@@ -983,10 +980,8 @@ export async function subscribeToRelays(
 
   const hasAcceptedForInstance = (url: string) =>
     allRelays.some((r) => r.url === url && r.status === "accepted");
-  // Terminal for the designated bot + URL. `accepted` is permanent; a Reject
-  // expires after RELAY_REJECT_RETRY_MS so a relay that denied us under a
-  // subscription format we have since fixed gets asked again rather than
-  // staying frozen forever. Pending always retries.
+  // Terminal for the designated bot + URL. Rejects expire (see isRelayTerminal)
+  // so a relay isn't frozen by a denial from a since-fixed format.
   const now = new Date();
   const designatedTerminalUrls = new Set(
     allRelays

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -57,6 +57,8 @@ export const following = pgTable(
     targetActorId: text("target_actor_id"),
     followActivityId: text("follow_activity_id"),
     status: text().notNull().default("pending"),
+    /** When `status` last changed. Null for rows written before this column. */
+    statusChangedAt: timestamp("status_changed_at", { withTimezone: true, mode: "date" }),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
     deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "date" }),
   },
@@ -78,6 +80,11 @@ export const relays = pgTable(
     inboxUrl: text("inbox_url"),
     actorId: text("actor_id"),
     status: relayStatusEnum().notNull().default("pending"),
+    /**
+     * When `status` last changed. Drives the Reject cooldown in
+     * `isRelayTerminal`; null for rows written before this column existed.
+     */
+    statusChangedAt: timestamp("status_changed_at", { withTimezone: true, mode: "date" }),
     followActivityId: text("follow_activity_id"),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
     deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "date" }),

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -57,7 +57,7 @@ export const following = pgTable(
     targetActorId: text("target_actor_id"),
     followActivityId: text("follow_activity_id"),
     status: text().notNull().default("pending"),
-    /** When `status` last changed. Null for rows written before this column. */
+    /** When `status` last changed; null for pre-existing rows. */
     statusChangedAt: timestamp("status_changed_at", { withTimezone: true, mode: "date" }),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
     deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "date" }),
@@ -80,10 +80,7 @@ export const relays = pgTable(
     inboxUrl: text("inbox_url"),
     actorId: text("actor_id"),
     status: relayStatusEnum().notNull().default("pending"),
-    /**
-     * When `status` last changed. Drives the Reject cooldown in
-     * `isRelayTerminal`; null for rows written before this column existed.
-     */
+    /** When `status` last changed; null for pre-existing rows. Drives the Reject cooldown. */
     statusChangedAt: timestamp("status_changed_at", { withTimezone: true, mode: "date" }),
     followActivityId: text("follow_activity_id"),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -1,25 +1,15 @@
-/**
- * Decisions about when a stored subscription row may be re-attempted.
- *
- * Both relay subscriptions and account follows record a terminal status that
- * stops us re-sending a Follow forever. That is right for `accepted` and wrong
- * for everything else: a Reject from four months ago, or an Accept that was
- * delivered but never matched a row, leaves the subscription frozen with no way
- * back. These helpers are the two escape hatches.
- */
+/** Escape hatches from terminal subscription state that would otherwise stick forever. */
 
-/** How long a relay Reject is honored before we re-attempt the subscription. */
+/** How long a relay Reject is honored before we re-attempt. */
 export const RELAY_REJECT_RETRY_MS = 30 * 24 * 60 * 60 * 1000;
 
 export type RelayStatus = "pending" | "accepted" | "rejected";
 
 /**
- * Whether a relay row should still block a new Follow.
- *
- * `accepted` is permanent. `rejected` expires, so a relay that denied us under
- * a subscription format we have since fixed gets asked again instead of staying
- * frozen. A rejection with no recorded time predates `status_changed_at`; ask
- * once, and the reply stamps the column so the cooldown applies from then on.
+ * Whether a relay row should still block a new Follow. `accepted` is permanent;
+ * `rejected` expires so a relay we were denied by under a since-fixed
+ * subscription format gets re-asked. A null time predates the column — ask once,
+ * and the reply stamps it.
  */
 export function isRelayTerminal(
   status: RelayStatus,
@@ -39,18 +29,15 @@ export function isRelayTerminal(
   return now.getTime() - statusChangedAt.getTime() < retryAfterMs;
 }
 
-/** Compares actor URIs ignoring a trailing slash, which instances vary on. */
+/** Instances vary on trailing slashes. */
 function normalizeActorId(id: string): string {
   return id.endsWith("/") ? id.slice(0, -1) : id;
 }
 
 /**
- * Given our still-pending follows of one target and that target's followers
- * collection, returns the bots the target already considers followers.
- *
- * These are follows whose `Accept` was delivered but never recorded — the
- * target will not re-Accept a duplicate Follow, so retrying can never clear
- * them. An empty `followerIds` (an actor that hides its followers) yields
+ * Pending follows the target already lists as followers — an Accept that was
+ * delivered but never recorded. The target won't re-Accept a duplicate Follow,
+ * so retrying can't clear these. Empty `followerIds` (hidden followers) yields
  * nothing, so the caller falls back to re-sending.
  */
 export function findLostAccepts(

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -1,0 +1,67 @@
+/**
+ * Decisions about when a stored subscription row may be re-attempted.
+ *
+ * Both relay subscriptions and account follows record a terminal status that
+ * stops us re-sending a Follow forever. That is right for `accepted` and wrong
+ * for everything else: a Reject from four months ago, or an Accept that was
+ * delivered but never matched a row, leaves the subscription frozen with no way
+ * back. These helpers are the two escape hatches.
+ */
+
+/** How long a relay Reject is honored before we re-attempt the subscription. */
+export const RELAY_REJECT_RETRY_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type RelayStatus = "pending" | "accepted" | "rejected";
+
+/**
+ * Whether a relay row should still block a new Follow.
+ *
+ * `accepted` is permanent. `rejected` expires, so a relay that denied us under
+ * a subscription format we have since fixed gets asked again instead of staying
+ * frozen. A rejection with no recorded time predates `status_changed_at`; ask
+ * once, and the reply stamps the column so the cooldown applies from then on.
+ */
+export function isRelayTerminal(
+  status: RelayStatus,
+  statusChangedAt: Date | null,
+  now: Date,
+  retryAfterMs: number = RELAY_REJECT_RETRY_MS,
+): boolean {
+  if (status === "accepted") {
+    return true;
+  }
+  if (status !== "rejected") {
+    return false;
+  }
+  if (statusChangedAt === null) {
+    return false;
+  }
+  return now.getTime() - statusChangedAt.getTime() < retryAfterMs;
+}
+
+/** Compares actor URIs ignoring a trailing slash, which instances vary on. */
+function normalizeActorId(id: string): string {
+  return id.endsWith("/") ? id.slice(0, -1) : id;
+}
+
+/**
+ * Given our still-pending follows of one target and that target's followers
+ * collection, returns the bots the target already considers followers.
+ *
+ * These are follows whose `Accept` was delivered but never recorded — the
+ * target will not re-Accept a duplicate Follow, so retrying can never clear
+ * them. An empty `followerIds` (an actor that hides its followers) yields
+ * nothing, so the caller falls back to re-sending.
+ */
+export function findLostAccepts(
+  pending: ReadonlyArray<{ botUsername: string; actorId: string | null }>,
+  followerIds: ReadonlySet<string>,
+): string[] {
+  if (followerIds.size === 0) {
+    return [];
+  }
+  const normalized = new Set([...followerIds].map(normalizeActorId));
+  return pending
+    .filter((row) => row.actorId !== null && normalized.has(normalizeActorId(row.actorId)))
+    .map((row) => row.botUsername);
+}


### PR DESCRIPTION
Both `relays` and `following` recorded terminal states nothing could undo. Prod had frozen rows of each kind, found while working out why /status showed two rejected relays and two pending follows.

## Relay Rejects expire

`relay.toot.io` and `relay.intahnet.co.uk` were rejected 2026-04-23, from a Follow sent partway through that evening's subscription-format fixes (#90). `subscribeToRelays` treats `accepted|rejected` as terminal, so the fixed code never asked again — four months of `has terminal state for relay ..., skipping`. Both relay actors are live.

`accepted` stays permanent; `rejected` now expires after 30 days. A relay that genuinely denies us re-Rejects, restamping the cooldown — one Follow per month. A relay that never replies leaves the row `pending`, still re-sent every boot as today. `scripts/resubscribe-relays.ts` remains the manual override.

## Lost Accepts get reconciled

`import_ai` and `hell_gate` sat pending on `_followback@tags.pub` since 2026-04-22 while tags.pub listed both as followers and had followed both back. The Accept was delivered but never matched a row, and a duplicate Follow doesn't produce a second one — so the boot-time retry re-sent forever with nothing to catch. 15h of logs had zero Accept activities.

`followAccounts` now reads the target's followers collection before re-sending and records what's already there. Hidden followers yield an empty set and we fall back to re-sending, so this can't manufacture a false accept.

Reads pages via `itemIds`; `traverseCollection` dereferences every entry and throws when one 404s, which tags.pub's collection does.

Plus `status_changed_at` on both tables, which the cooldown needs.

## Testing

- `subscriptions.test.ts` covers cooldown boundaries and reconciliation, including hidden-followers and null-actor-id.
- `db.test.ts` covers `markFollowingAccepted` scoping.
- 166 tests pass against real Postgres locally including migration 0015. CI has no `DATABASE_URL`, so DB-backed cases skip there.
- Fetch path verified against live `_followback@tags.pub`: 16 pages, 784 IDs, returns exactly `import_ai` and `hell_gate`.
- Standalone output boots on `node:26-slim` — no tracing gap.

The four prod rows were fixed by hand; this stops it recurring.