### PR TITLE
fix: send relay Follow object as the full Public IRI

### DIFF
--- a/src/lib/__tests__/subscriptions.test.ts
+++ b/src/lib/__tests__/subscriptions.test.ts
@@ -1,9 +1,48 @@
 import { describe, it, expect } from "vitest";
+import { Follow, PUBLIC_COLLECTION } from "@fedify/vocab";
 import {
   RELAY_REJECT_RETRY_MS,
   isRelayTerminal,
   findLostAccepts,
+  RelayFollow,
+  AS_PUBLIC,
 } from "../subscriptions";
+
+const FOLLOW_ARGS = {
+  id: new URL("https://robot.villas/users/nyt_homepage/follows/x"),
+  actor: new URL("https://robot.villas/users/nyt_homepage"),
+  object: PUBLIC_COLLECTION,
+};
+
+describe("RelayFollow", () => {
+  it("serializes object as the full Public IRI", async () => {
+    const json = (await new RelayFollow(FOLLOW_ARGS).toJsonLd()) as Record<string, unknown>;
+    expect(json.object).toBe(AS_PUBLIC);
+    expect(json.type).toBe("Follow");
+  });
+
+  it("documents the upstream behaviour it works around", async () => {
+    // Plain Follow compacts to the CURIE, which YUKIMOCHI Activity-Relay
+    // rejects because it string-compares against the full IRI.
+    const json = (await new Follow(FOLLOW_ARGS).toJsonLd()) as Record<string, unknown>;
+    expect(json.object).toBe("as:Public");
+  });
+
+  it("survives clone(), which Fedify uses internally", async () => {
+    const cloned = new RelayFollow(FOLLOW_ARGS).clone({});
+    expect(cloned).toBeInstanceOf(RelayFollow);
+    const json = (await cloned.toJsonLd()) as Record<string, unknown>;
+    expect(json.object).toBe(AS_PUBLIC);
+  });
+
+  it("leaves a non-Public object untouched", async () => {
+    const json = (await new RelayFollow({
+      ...FOLLOW_ARGS,
+      object: new URL("https://tags.pub/user/_followback"),
+    }).toJsonLd()) as Record<string, unknown>;
+    expect(json.object).toBe("https://tags.pub/user/_followback");
+  });
+});
 
 const NOW = new Date("2026-08-16T00:00:00Z");
 const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -37,7 +37,7 @@ import {
 } from "@fedify/vocab";
 import escapeHtml from "escape-html";
 import { getRelaySubscriptionBot, type BotConfig, type FeedsConfig } from "./config";
-import { findLostAccepts, isRelayTerminal } from "./subscriptions";
+import { findLostAccepts, isRelayTerminal, RelayFollow } from "./subscriptions";
 import {
   addFollower,
   countEntries,
@@ -509,7 +509,9 @@ export function setupFederation(deps: FederationDeps): Federation<void> {
       // Also check the relays table (relay subscriptions)
       const relayRow = await getRelayByActivityId(db, followUri.href);
       if (relayRow?.actorId) {
-        return new Follow({
+        // RelayFollow, not Follow: the relay re-fetches this URL to verify the
+        // subscription and applies the same full-IRI string check.
+        return new RelayFollow({
           id: followUri,
           actor: ctx.getActorUri(identifier),
           object: PUBLIC_COLLECTION,
@@ -1037,12 +1039,13 @@ export async function subscribeToRelays(
         id: crypto.randomUUID(),
       });
 
-      const follow = new Follow({
+      const follow = new RelayFollow({
         id: followId,
         actor: ctx.getActorUri(designated),
         // ActivityRelay expects object=PUBLIC_COLLECTION (Mastodon-style subscription),
         // not the relay actor's own URL (which triggers the LitePub peer-relay path
         // and gets rejected because our actor URLs don't end in /relay).
+        // RelayFollow serializes it as the full IRI; see its docstring.
         object: PUBLIC_COLLECTION,
       });
 

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -1,4 +1,33 @@
-/** Escape hatches from terminal subscription state that would otherwise stick forever. */
+/** Relay and follow subscription helpers: retry policy, reconciliation, wire format. */
+
+import { Follow } from "@fedify/vocab";
+
+export const AS_PUBLIC = "https://www.w3.org/ns/activitystreams#Public";
+
+/**
+ * A Follow that serializes `object` as the full Public IRI instead of the
+ * `as:Public` CURIE that JSON-LD compaction produces.
+ *
+ * YUKIMOCHI Activity-Relay — which relay.toot.io and relay.intahnet.co.uk both
+ * run — validates subscriptions with a literal string comparison against the
+ * full IRI, so the compacted form falls through to its "only
+ * https://www.w3.org/ns/activitystreams#Public is allowed to follow" Reject.
+ * Fedify applies the same rewrite to to/cc/bto/bcc/audience as of 2.2.0 but not
+ * to `object`. Rewriting inside toJsonLd keeps the signed bytes and the wire
+ * bytes identical.
+ */
+export class RelayFollow extends Follow {
+  override async toJsonLd(options?: Parameters<Follow["toJsonLd"]>[0]): Promise<unknown> {
+    const json = await super.toJsonLd(options);
+    if (json && typeof json === "object") {
+      const doc = json as Record<string, unknown>;
+      if (doc.object === "as:Public" || doc.object === "Public") {
+        doc.object = AS_PUBLIC;
+      }
+    }
+    return json;
+  }
+}
 
 /** How long a relay Reject is honored before we re-attempt. */
 export const RELAY_REJECT_RETRY_MS = 30 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
`relay.toot.io` and `relay.intahnet.co.uk` weren't dead and weren't refusing us on policy — we were sending a Follow they can't parse.

## Cause

Both run [YUKIMOCHI Activity-Relay](https://github.com/yukimochi/Activity-Relay), both auto-accept (toot.io lists 1,324 connected instances), and both Rejected within 3.5 minutes of a fresh, correctly-formatted Follow after #139 deployed. Its `executeFollowing` validates with a literal string comparison:

```go
case contains(activity.Object, "https://www.w3.org/ns/activitystreams#Public"):
    // contains(string) → entry == key
...
default:
    return errors.New("only https://www.w3.org/ns/activitystreams#Public is allowed to follow")
```

What we put on the wire:

```
type  : Follow
actor : https://robot.villas/users/nyt_homepage
object: "as:Public"
```

`"as:Public" != "https://www.w3.org/ns/activitystreams#Public"` → falls to `default` → Reject. Semantically we're right — the CURIE expands to that IRI — but the relay string-matches, so we lose.

Fedify hit this class of bug against Lemmy and shipped the same rewrite in 2.2.0 ([#710](https://github.com/fedify-dev/fedify/pull/710)), but only for `to`/`cc`/`bto`/`bcc`/`audience`, not `object`. We're on 2.3.4, so there's nothing to upgrade to.

## Fix

`RelayFollow` overrides `toJsonLd` to emit the full IRI. Doing it inside `toJsonLd` rather than post-serialization keeps the Object Integrity Proof over the same bytes that go on the wire — the same ordering constraint #710 calls out.

Applied in both places a relay Follow is produced: the sent activity, and the Follow object dispatcher (the relay re-fetches that URL to verify the subscription, and applies the same check).

## Testing

- Four new cases: full IRI emitted, `clone()` preserves the subclass (Fedify clones internally), non-Public objects untouched, and one asserting plain `Follow` still compacts to `as:Public` so the upstream behaviour this works around is pinned.
- 174 tests pass against real Postgres.

Real verification is the relays themselves: after deploy, reset the two rows to pending and watch for Accept.