### PR TITLE
fix: use lithub's own logo for its profile photo

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -834,7 +834,7 @@ bots:
     homepage_url: https://lithub.com
     display_name: Literary Hub
     summary: Books, literature, essays, publishing, and literary culture.
-    profile_photo: https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://lithub.com&size=128
+    profile_photo: https://s26162.pcdn.co/wp-content/themes/lithub-prime/img/logo-compact.png
   strong_towns:
     feed_url: https://www.strongtowns.org/journal/rss.xml
     homepage_url: https://www.strongtowns.org


### PR DESCRIPTION
`validate-feeds` has been red on `main` since 2026-08-15 with `✗ [lithub] HTTP 404`.

The URL was Google's `t1.gstatic.com` favicon proxy, which answers per-edge: 200 from my machine, 404 from GitHub runners. So the job failed in CI while passing locally.

Now points at the logo on lithub's own CDN — a real 308×172 `image/png` on a stable theme path. Their site offers nothing squarer: `apple-touch-icon.png` and `/favicon.ico` both 404, the declared icon is an `.ico` the validator rejects, and `og:image` is blank. Wordmark, so it'll crop in circular avatars.

**42 other feeds use the same proxy** and can rot identically. Left alone to keep this PR to the failing entry.

Verified by CI, since the 404 only reproduces from a runner.