### PR TITLE
fix: clear feed_poll_status when a bot is deleted

### DIFF
--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -14,6 +14,9 @@ import {
   removeFollower,
   getKeypairs,
   saveKeypairs,
+  upsertFeedPollStatus,
+  removeFeedPollStatus,
+  getFeedPollStatusMap,
   upsertFollowing,
   markFollowingAccepted,
   getAllFollowing,
@@ -291,6 +294,30 @@ describeWithDb("database", () => {
       const kps = await getKeypairs(db, "legacybot");
       expect(kps).toHaveLength(1);
       expect(kps![0].publicKey).toMatchObject({ kty: "RSA", n: "legacy" });
+    });
+  });
+
+  describe("feed_poll_status cleanup", () => {
+    it("removeFeedPollStatus deletes only that bot's row", async () => {
+      // Removing a bot left its poll status behind — 18 orphans accumulated
+      // in prod because the deleted-bot cleanup never touched this table.
+      for (const botUsername of ["bot_a", "bot_b"]) {
+        await upsertFeedPollStatus(db, {
+          botUsername,
+          lastCheckedAt: new Date(),
+          lastHttpStatus: 200,
+          lastError: null,
+          etag: null,
+          lastModified: null,
+          nextPollAt: null,
+        });
+      }
+
+      await removeFeedPollStatus(db, "bot_a");
+
+      const remaining = await getFeedPollStatusMap(db, ["bot_a", "bot_b"]);
+      expect(remaining.has("bot_a")).toBe(false);
+      expect(remaining.has("bot_b")).toBe(true);
     });
   });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -418,6 +418,11 @@ export async function removeKeypairs(db: Db, botUsername: string): Promise<void>
     .where(and(eq(schema.actorKeypairs.botUsername, botUsername), isNull(schema.actorKeypairs.deletedAt)));
 }
 
+/** Hard delete: feed_poll_status has no deleted_at, one row per bot. */
+export async function removeFeedPollStatus(db: Db, botUsername: string): Promise<void> {
+  await db.delete(schema.feedPollStatus).where(eq(schema.feedPollStatus.botUsername, botUsername));
+}
+
 export async function removeAllFollowers(db: Db, botUsername: string): Promise<void> {
   await db
     .update(schema.followers)

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -67,6 +67,7 @@ import {
   removeAllFollowing,
   removeFollower,
   removeFollowerFromAll,
+  removeFeedPollStatus,
   removeKeypairs,
   saveKeypairs,
   updateFollowerInboxUrl,
@@ -1157,6 +1158,7 @@ export async function sendDeletedBotActivities(
     await removeAllEntries(db, botUsername);
     await removeAllFollowing(db, botUsername);
     await removeKeypairs(db, botUsername);
+    await removeFeedPollStatus(db, botUsername);
     logger.info("Cleaned up database for deleted bot {identifier}", {
       identifier: botUsername,
     });


### PR DESCRIPTION
Auditing every table's `bot_username` set against `feeds.yml` turned up one leak:

```
feed_entries      0 orphans
followers         0 orphans
following         0 orphans
actor_keypairs    0 orphans
feed_poll_status  18 orphans   ← ap_top_news, citylab, cnn_*, gwern, hbr,
                                 rachelbythebay, wsj_*, …
```

`sendDeletedBotActivities` cleans followers, entries, following, and keypairs. `feed_poll_status` was added later and never wired in, so every removed feed left a row behind.

Hard delete rather than soft — that table has no `deleted_at` and is one row per bot.

Prod's 18 rows are already cleaned; all tables now sit at 187.