### PR TITLE
chore: add Daring Fireball bot feed entry

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -1132,6 +1132,12 @@ bots:
     homepage_url: https://horn.gg
     display_name: David Horn
     summary: Writing about AI, technology, games, and culture.
+  daring_fireball:
+    feed_url: https://daringfireball.net/feeds/main
+    homepage_url: https://daringfireball.net
+    display_name: Daring Fireball
+    summary: John Gruber's writing about Apple, design, and technology.
+    profile_photo: https://daringfireball.net/graphics/apple-touch-icon.png
 relay_subscription_bot: nyt_homepage
 follows:
   - '@icco@merveilles.town'


### PR DESCRIPTION
Adds `daring_fireball` (@daring_fireball@robot.villas) mirroring https://daringfireball.net/feeds/main.

`pnpm validate-feeds` passes: schema valid (189 bots), profile photo reachable as image/png.

Note: DF's Atom entries put the linked article in `rel=alternate`, so linked-list posts will link out to the source rather than the DF permalink — that's how the feed is designed. GUIDs come from `<id>` (`tag:daringfireball.net,...`), so dedup is stable.