### PR TITLE
fix: link Wikipedia featured posts to the article, not Special:FeedItem

### DIFF
--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -468,6 +468,12 @@ describe("unwrapMediaWikiFeedItem", () => {
     expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, html)?.title).toBe("Pat O'Keeffe");
   });
 
+  it("leaves other MediaWiki feeds alone, whose blurbs bold links that aren't the subject", () => {
+    const html = blurb(`<b><a href="/wiki/Mesklin" title="Mesklin">Mesklin</a></b>`);
+    const onThisDay = "https://en.wikipedia.org/wiki/Special:FeedItem/onthisday/20260822000000/en";
+    expect(unwrapMediaWikiFeedItem(onThisDay, html)).toBeNull();
+  });
+
   it("leaves non-MediaWiki links alone", () => {
     const html = blurb(`<b><a href="/wiki/Mesklin" title="Mesklin">Mesklin</a></b>`);
     expect(unwrapMediaWikiFeedItem("https://example.com/post/1", html)).toBeNull();

--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -11,6 +11,7 @@ import {
   parseFeedXml,
   parseRetryAfterMs,
   toFeedText,
+  unwrapMediaWikiFeedItem,
   type FeedEntry,
 } from "../rss";
 import type { Item } from "rss-parser";
@@ -402,5 +403,106 @@ describe("parseFeedXml with an attributes-only guid", () => {
     expect(typeof entries[0].guid).toBe("string");
     expect(entries[0].guid).toBe("https://example.com/a-post");
     expect(entries[0].title).toBe("A Post");
+  });
+});
+
+describe("unwrapMediaWikiFeedItem", () => {
+  const FEED_ITEM_LINK = "https://en.wikipedia.org/wiki/Special:FeedItem/featured/20260822000000/en";
+  const blurb = (inner: string) =>
+    `<div class="mw-content-ltr mw-parser-output" lang="en" dir="ltr">` +
+    `<span typeof="mw:File"><a href="/wiki/File:Photo.jpg" class="mw-file-description" title="Photo">` +
+    `<img alt="Photo" src="//upload.wikimedia.org/photo.jpg"/></a></span>` +
+    `<p>${inner}</p></div>`;
+
+  it("uses the lead bolded article link when the blurb closes with 'Full article...'", () => {
+    const html = blurb(
+      `The <b><a href="/wiki/European_rabbit" title="European rabbit">European rabbit</a></b> is a` +
+        ` species of rabbit. <i>(<b><a href="/wiki/European_rabbit" title="European rabbit">Full` +
+        ` article...</a></b>)</i>`,
+    );
+    expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, html)).toEqual({
+      link: "https://en.wikipedia.org/wiki/European_rabbit",
+      title: "European rabbit",
+    });
+  });
+
+  it("handles the featured-topic blurb, which says 'This article' instead", () => {
+    const html = blurb(
+      `<b><a href="/wiki/SMS_Schwaben" title="SMS Schwaben">SMS Schwaben</a></b> was a battleship.` +
+        ` <i>(<b><a href="/wiki/SMS_Schwaben" title="SMS Schwaben">This article</a></b> is part of a` +
+        ` <a href="/wiki/Wikipedia:Featured_topics" title="Wikipedia:Featured topics">featured` +
+        ` topic</a>.)</i>`,
+    );
+    expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, html)?.link).toBe(
+      "https://en.wikipedia.org/wiki/SMS_Schwaben",
+    );
+  });
+
+  it("skips bolded links into non-article namespaces", () => {
+    const html = blurb(
+      `<b><a href="/wiki/Wikipedia:Featured_topics" title="Wikipedia:Featured topics">A topic</a></b>` +
+        ` covers <b><a href="/wiki/Mesklin" title="Mesklin">Mesklin</a></b>.`,
+    );
+    expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, html)?.link).toBe(
+      "https://en.wikipedia.org/wiki/Mesklin",
+    );
+  });
+
+  it("resolves against the entry link, so non-English wikis keep their host", () => {
+    const html = blurb(`<b><a href="/wiki/Berlin" title="Berlin">Berlin</a></b> ist eine Stadt.`);
+    expect(
+      unwrapMediaWikiFeedItem(
+        "https://de.wikipedia.org/wiki/Spezial:FeedItem/featured/20260822000000/de".replace(
+          "Spezial:FeedItem",
+          "Special:FeedItem",
+        ),
+        html,
+      )?.link,
+    ).toBe("https://de.wikipedia.org/wiki/Berlin");
+  });
+
+  it("normalizes typography in the article title", () => {
+    const html = blurb(
+      `<b><a href="/wiki/Pat_O%27Keeffe" title="Pat O&#8217;Keeffe">Pat O'Keeffe</a></b> was a boxer.`,
+    );
+    expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, html)?.title).toBe("Pat O'Keeffe");
+  });
+
+  it("leaves non-MediaWiki links alone", () => {
+    const html = blurb(`<b><a href="/wiki/Mesklin" title="Mesklin">Mesklin</a></b>`);
+    expect(unwrapMediaWikiFeedItem("https://example.com/post/1", html)).toBeNull();
+  });
+
+  it("returns null when the blurb has no bolded article link", () => {
+    expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, blurb("Just prose, no links."))).toBeNull();
+    expect(unwrapMediaWikiFeedItem(FEED_ITEM_LINK, "")).toBeNull();
+  });
+});
+
+describe("parseFeedXml on a MediaWiki featuredfeed", () => {
+  const WIKI_ATOM = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+  <title>Wikipedia featured articles feed</title>
+  <entry>
+    <id>https://en.wikipedia.org/wiki/Special:FeedItem/featured/20260822000000/en</id>
+    <title>August 22 Wikipedia featured article</title>
+    <link rel="alternate" type="text/html" href="https://en.wikipedia.org/wiki/Special:FeedItem/featured/20260822000000/en"/>
+    <updated>2026-08-22T00:00:00Z</updated>
+    <summary type="html">&lt;p&gt;The &lt;b&gt;&lt;a href="/wiki/Edmontosaurus_mummy_SMF_R_4036" title="Edmontosaurus mummy SMF R 4036"&gt;Edmontosaurus mummy SMF R 4036&lt;/a&gt;&lt;/b&gt; is a dinosaur fossil.&lt;/p&gt;</summary>
+  </entry>
+</feed>`;
+
+  it("publishes the article, not the Special:FeedItem wrapper", async () => {
+    const entries = await parseFeedXml(WIKI_ATOM);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].link).toBe("https://en.wikipedia.org/wiki/Edmontosaurus_mummy_SMF_R_4036");
+    expect(entries[0].title).toBe("Edmontosaurus mummy SMF R 4036");
+  });
+
+  it("keeps the guid on the feed's own id, so unwrapping never reposts an entry", async () => {
+    const entries = await parseFeedXml(WIKI_ATOM);
+    expect(entries[0].guid).toBe(
+      "https://en.wikipedia.org/wiki/Special:FeedItem/featured/20260822000000/en",
+    );
   });
 });

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -264,13 +264,13 @@ export function toFeedText(value: unknown): string {
   return "";
 }
 
-/** MediaWiki `featuredfeed` entry links, e.g. `/wiki/Special:FeedItem/featured/20260822000000/en`. */
-const MEDIAWIKI_FEED_ITEM_LINK = /^https?:\/\/[^/]+\/wiki\/Special:FeedItem\//i;
+/** Pinned to `featured`: `onthisday` and `potd` blurbs bold links that aren't the subject. */
+const MEDIAWIKI_FEED_ITEM_LINK = /^https?:\/\/[^/]+\/wiki\/Special:FeedItem\/featured\//i;
 
-/** Opening tag of a bolded link in a blurb, capturing its attributes. */
+/** Opening tag of a bolded link, capturing its attributes. */
 const BOLD_ANCHOR = /<b>\s*<a\s+([^>]*)>/i;
 
-/** Namespaced targets that are chrome around the blurb, never the article it features. */
+/** Chrome around the blurb, never the article it features. */
 const NON_ARTICLE_TARGET = /^\/wiki\/(?:File|Image|Wikipedia|Portal|Help|Template|Category|Special):/i;
 
 function htmlAttr(attrs: string, name: string): string | null {
@@ -279,16 +279,10 @@ function htmlAttr(attrs: string, name: string): string | null {
 }
 
 /**
- * Pulls the article a MediaWiki `featuredfeed` entry is about out of its blurb.
- *
- * The entry's own `<link>` points at a `Special:FeedItem` wrapper: a `noindex` page titled
- * after the date ("August 22 Wikipedia featured article") with no OpenGraph metadata, so
- * clients render it as a bare link and readers land somewhere other than the article. The
- * real target is the first bolded article link in the blurb — the lead mention, which every
- * blurb layout carries whether it closes with "Full article..." or "This article is part of
- * a featured topic".
- *
- * Returns null when the blurb has no such link, leaving the entry as the feed supplied it.
+ * Resolves the article behind a `featuredfeed` entry, whose own `<link>` is a `noindex`
+ * `Special:FeedItem` wrapper titled after the date. The article is the blurb's first bolded
+ * article link, present in both blurb layouts ("Full article..." and "This article is part
+ * of a featured topic"). Null when absent, leaving the entry as the feed supplied it.
  */
 export function unwrapMediaWikiFeedItem(
   itemLink: string,
@@ -304,14 +298,13 @@ export function unwrapMediaWikiFeedItem(
       return null;
     }
     const href = htmlAttr(m[1], "href");
-    if (href?.startsWith("/wiki/") && !NON_ARTICLE_TARGET.test(href)) {
-      // Resolve against the entry link so this works on any language wiki, not just en.
-      const link = new URL(href, itemLink).href;
-      const rawTitle = htmlAttr(m[1], "title");
-      if (!rawTitle) {
-        return null;
-      }
-      return { link, title: normalizeTypography(decodeHtmlEntities(rawTitle)) };
+    const rawTitle = htmlAttr(m[1], "title");
+    if (href?.startsWith("/wiki/") && rawTitle && !NON_ARTICLE_TARGET.test(href)) {
+      return {
+        // Resolve against the entry link so this works on any language wiki, not just en.
+        link: new URL(href, itemLink).href,
+        title: normalizeTypography(decodeHtmlEntities(rawTitle)),
+      };
     }
     rest = rest.slice(m.index! + m[0].length);
   }
@@ -323,7 +316,7 @@ function normalizeFeedItem(item: Parser.Item): FeedEntry {
   const itemTitle = toFeedText(item.title);
   const itemLink = toFeedText(item.link);
   const guid = toFeedText(item.guid) || toFeedText(raw.id) || itemLink || itemTitle || "";
-  // Deliberately after `guid`: unwrapping must not change identity, or every entry reposts.
+  // After `guid` on purpose: unwrapping must not change identity, or every entry reposts.
   const unwrapped = unwrapMediaWikiFeedItem(itemLink, toFeedText(raw.summary));
   const title = unwrapped
     ? unwrapped.title

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -264,13 +264,71 @@ export function toFeedText(value: unknown): string {
   return "";
 }
 
+/** MediaWiki `featuredfeed` entry links, e.g. `/wiki/Special:FeedItem/featured/20260822000000/en`. */
+const MEDIAWIKI_FEED_ITEM_LINK = /^https?:\/\/[^/]+\/wiki\/Special:FeedItem\//i;
+
+/** Opening tag of a bolded link in a blurb, capturing its attributes. */
+const BOLD_ANCHOR = /<b>\s*<a\s+([^>]*)>/i;
+
+/** Namespaced targets that are chrome around the blurb, never the article it features. */
+const NON_ARTICLE_TARGET = /^\/wiki\/(?:File|Image|Wikipedia|Portal|Help|Template|Category|Special):/i;
+
+function htmlAttr(attrs: string, name: string): string | null {
+  const m = attrs.match(new RegExp(`${name}="([^"]*)"`, "i"));
+  return m ? m[1] : null;
+}
+
+/**
+ * Pulls the article a MediaWiki `featuredfeed` entry is about out of its blurb.
+ *
+ * The entry's own `<link>` points at a `Special:FeedItem` wrapper: a `noindex` page titled
+ * after the date ("August 22 Wikipedia featured article") with no OpenGraph metadata, so
+ * clients render it as a bare link and readers land somewhere other than the article. The
+ * real target is the first bolded article link in the blurb — the lead mention, which every
+ * blurb layout carries whether it closes with "Full article..." or "This article is part of
+ * a featured topic".
+ *
+ * Returns null when the blurb has no such link, leaving the entry as the feed supplied it.
+ */
+export function unwrapMediaWikiFeedItem(
+  itemLink: string,
+  summaryHtml: string,
+): { link: string; title: string } | null {
+  if (!MEDIAWIKI_FEED_ITEM_LINK.test(itemLink) || !summaryHtml) {
+    return null;
+  }
+  let rest = summaryHtml;
+  while (rest) {
+    const m = rest.match(BOLD_ANCHOR);
+    if (!m) {
+      return null;
+    }
+    const href = htmlAttr(m[1], "href");
+    if (href?.startsWith("/wiki/") && !NON_ARTICLE_TARGET.test(href)) {
+      // Resolve against the entry link so this works on any language wiki, not just en.
+      const link = new URL(href, itemLink).href;
+      const rawTitle = htmlAttr(m[1], "title");
+      if (!rawTitle) {
+        return null;
+      }
+      return { link, title: normalizeTypography(decodeHtmlEntities(rawTitle)) };
+    }
+    rest = rest.slice(m.index! + m[0].length);
+  }
+  return null;
+}
+
 function normalizeFeedItem(item: Parser.Item): FeedEntry {
   const raw = item as Record<string, unknown>;
   const itemTitle = toFeedText(item.title);
   const itemLink = toFeedText(item.link);
   const guid = toFeedText(item.guid) || toFeedText(raw.id) || itemLink || itemTitle || "";
-  const title = normalizeTypography(decodeHtmlEntities(itemTitle || "(untitled)"));
-  const link = itemLink;
+  // Deliberately after `guid`: unwrapping must not change identity, or every entry reposts.
+  const unwrapped = unwrapMediaWikiFeedItem(itemLink, toFeedText(raw.summary));
+  const title = unwrapped
+    ? unwrapped.title
+    : normalizeTypography(decodeHtmlEntities(itemTitle || "(untitled)"));
+  const link = unwrapped ? unwrapped.link : itemLink;
   const publishedAt = item.isoDate ? new Date(item.isoDate) : null;
   return { guid, title, link, publishedAt, feedCategories: extractFeedCategories(item) };
 }


### PR DESCRIPTION
Wikipedia posts link to `Special:FeedItem` wrapper pages. Those return 200, but they are `noindex`, have no OpenGraph tags, and are titled after the date — so posts read "August 22 Wikipedia featured article" and clients show a bare, preview-less link instead of the article.

The article is only in the blurb. `unwrapMediaWikiFeedItem` takes the first bolded article link there, which both blurb layouts carry — the usual "Full article..." close and the "This article is part of a featured topic" variant (Aug 19). Scoped to `featured`; `onthisday`/`potd` bold links that are not the subject.

`guid` still comes from the entry id, so this reposts nothing. Verified against the live feed — all 10 entries resolve to real articles, titled with the article name.

Already-published rows keep their old URLs; only new entries pick this up.