### PR TITLE
fix: survive a database outage at boot instead of serving 500s forever

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,3 +1,7 @@
+const globalForBoot = globalThis as unknown as {
+  __robotVillasMigration?: Promise<void>;
+};
+
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") {
     return;
@@ -15,13 +19,17 @@ export async function register() {
 
   const { migrateWithRetry } = await import("@/lib/db");
   try {
-    await migrateWithRetry(db, (attempt, delayMs, error) => {
+    // Next re-runs register() per request until it succeeds, and measurably dedupes callers
+    // onto one in-flight hook. Pinning the promise makes that guarantee ours rather than
+    // Next's: two retry loops racing to migrate would be far worse than the outage.
+    globalForBoot.__robotVillasMigration ??= migrateWithRetry(db, (attempt, delayMs, error) => {
       logger.warn("Migration attempt {attempt} failed, retrying in {delayMs}ms: {error}", {
         attempt,
         delayMs,
         error,
       });
     });
+    await globalForBoot.__robotVillasMigration;
   } catch (err) {
     // Next re-runs register() per request, so throwing here would serve 500s forever while
     // the process stays alive and `restart: always` never fires. Exit so Docker restarts us.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -13,8 +13,23 @@ export async function register() {
   const { getLogger } = await import("@logtape/logtape");
   const logger = getLogger(["robot-villas", "server"]);
 
-  const { migrate } = await import("@/lib/db");
-  await migrate(db);
+  const { migrateWithRetry } = await import("@/lib/db");
+  try {
+    await migrateWithRetry(db, (attempt, delayMs, error) => {
+      logger.warn("Migration attempt {attempt} failed, retrying in {delayMs}ms: {error}", {
+        attempt,
+        delayMs,
+        error,
+      });
+    });
+  } catch (err) {
+    // Next re-runs register() per request, so throwing here would serve 500s forever while
+    // the process stays alive and `restart: always` never fires. Exit so Docker restarts us.
+    logger.fatal("Database migrations failed, exiting so the container restarts: {error}", {
+      error: err,
+    });
+    process.exit(1);
+  }
   logger.info("Database migrations complete");
 
   if (process.env.DISABLE_BACKGROUND === "true") {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -19,9 +19,8 @@ export async function register() {
 
   const { migrateWithRetry } = await import("@/lib/db");
   try {
-    // Next re-runs register() per request until it succeeds, and measurably dedupes callers
-    // onto one in-flight hook. Pinning the promise makes that guarantee ours rather than
-    // Next's: two retry loops racing to migrate would be far worse than the outage.
+    // Next re-runs register() per request until it succeeds. Pin the promise so the retry
+    // window can't put two migrations in flight at once.
     globalForBoot.__robotVillasMigration ??= migrateWithRetry(db, (attempt, delayMs, error) => {
       logger.warn("Migration attempt {attempt} failed, retrying in {delayMs}ms: {error}", {
         attempt,
@@ -31,8 +30,8 @@ export async function register() {
     });
     await globalForBoot.__robotVillasMigration;
   } catch (err) {
-    // Next re-runs register() per request, so throwing here would serve 500s forever while
-    // the process stays alive and `restart: always` never fires. Exit so Docker restarts us.
+    // Throwing would leave the process up and 500ing every request, so `restart: always`
+    // never fires. Exit and let Docker restart us.
     logger.fatal("Database migrations failed, exiting so the container restarts: {error}", {
       error: err,
     });

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -432,19 +432,24 @@ describeWithDb("database", () => {
 
 describe("migrateWithRetry", () => {
   const fakeDb = {} as Parameters<typeof migrateWithRetry>[0];
-  const unreachable = () => Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" });
+
+  function unreachable(): Error {
+    return Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" });
+  }
 
   it("succeeds without sleeping when the database is already up", async () => {
     const slept: number[] = [];
     let calls = 0;
+
     await migrateWithRetry(fakeDb, undefined, {
       run: async () => {
- calls++; 
-},
+        calls++;
+      },
       sleep: async (ms) => {
- slept.push(ms); 
-},
+        slept.push(ms);
+      },
     });
+
     expect(calls).toBe(1);
     expect(slept).toEqual([]);
   });
@@ -453,16 +458,18 @@ describe("migrateWithRetry", () => {
     const slept: number[] = [];
     const retries: number[] = [];
     let calls = 0;
+
     await migrateWithRetry(fakeDb, (attempt) => retries.push(attempt), {
       run: async () => {
         if (++calls < 3) {
-throw unreachable();
-}
+          throw unreachable();
+        }
       },
       sleep: async (ms) => {
- slept.push(ms); 
-},
+        slept.push(ms);
+      },
     });
+
     expect(calls).toBe(3);
     expect(slept).toEqual([1_000, 2_000]);
     expect(retries).toEqual([1, 2]);
@@ -471,16 +478,18 @@ throw unreachable();
   it("rethrows the last error once attempts are exhausted, so a broken migration surfaces", async () => {
     const slept: number[] = [];
     let calls = 0;
-    await expect(
-      migrateWithRetry(fakeDb, undefined, {
-        run: async () => {
- calls++; throw unreachable(); 
-},
-        sleep: async (ms) => {
- slept.push(ms); 
-},
-      }),
-    ).rejects.toThrow("connect EHOSTUNREACH");
+
+    const attempt = migrateWithRetry(fakeDb, undefined, {
+      run: async () => {
+        calls++;
+        throw unreachable();
+      },
+      sleep: async (ms) => {
+        slept.push(ms);
+      },
+    });
+
+    await expect(attempt).rejects.toThrow("connect EHOSTUNREACH");
     expect(calls).toBe(6);
     expect(slept).toEqual([1_000, 2_000, 4_000, 8_000, 15_000]);
   });

--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -4,6 +4,7 @@ import { inArray } from "drizzle-orm";
 import {
   createDb,
   migrate,
+  migrateWithRetry,
   hasEntry,
   getExistingGuids,
   insertEntry,
@@ -426,5 +427,61 @@ describeWithDb("database", () => {
       await seed();
       expect((await relayRow())!.statusChangedAt).toBeInstanceOf(Date);
     });
+  });
+});
+
+describe("migrateWithRetry", () => {
+  const fakeDb = {} as Parameters<typeof migrateWithRetry>[0];
+  const unreachable = () => Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" });
+
+  it("succeeds without sleeping when the database is already up", async () => {
+    const slept: number[] = [];
+    let calls = 0;
+    await migrateWithRetry(fakeDb, undefined, {
+      run: async () => {
+ calls++; 
+},
+      sleep: async (ms) => {
+ slept.push(ms); 
+},
+    });
+    expect(calls).toBe(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("retries with backoff while the database is still coming up", async () => {
+    const slept: number[] = [];
+    const retries: number[] = [];
+    let calls = 0;
+    await migrateWithRetry(fakeDb, (attempt) => retries.push(attempt), {
+      run: async () => {
+        if (++calls < 3) {
+throw unreachable();
+}
+      },
+      sleep: async (ms) => {
+ slept.push(ms); 
+},
+    });
+    expect(calls).toBe(3);
+    expect(slept).toEqual([1_000, 2_000]);
+    expect(retries).toEqual([1, 2]);
+  });
+
+  it("rethrows the last error once attempts are exhausted, so a broken migration surfaces", async () => {
+    const slept: number[] = [];
+    let calls = 0;
+    await expect(
+      migrateWithRetry(fakeDb, undefined, {
+        run: async () => {
+ calls++; throw unreachable(); 
+},
+        sleep: async (ms) => {
+ slept.push(ms); 
+},
+      }),
+    ).rejects.toThrow("connect EHOSTUNREACH");
+    expect(calls).toBe(6);
+    expect(slept).toEqual([1_000, 2_000, 4_000, 8_000, 15_000]);
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,13 +17,12 @@ export async function migrate(db: Db): Promise<void> {
   await runMigrations(db, { migrationsFolder: "./drizzle" });
 }
 
-/** Attempts, and the backoff before each retry. Spans ~30s, enough for a Postgres restart. */
+/** Backoff before each retry; ~30s total. Longer outages are covered by exiting and restarting. */
 const MIGRATE_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 15_000];
 
 /**
- * Runs {@link migrate}, retrying on any failure -- the expected one being a database that is
- * still coming up. Rethrows the last error once attempts are exhausted, so a genuinely broken
- * migration surfaces after ~30s instead of retrying forever.
+ * Runs {@link migrate}, retrying any failure -- normally a database still coming up. Rethrows
+ * the last error once attempts are exhausted, so a broken migration surfaces instead of looping.
  */
 export async function migrateWithRetry(
   db: Db,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,6 +17,39 @@ export async function migrate(db: Db): Promise<void> {
   await runMigrations(db, { migrationsFolder: "./drizzle" });
 }
 
+/** Attempts, and the backoff before each retry. Spans ~30s, enough for a Postgres restart. */
+const MIGRATE_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 15_000];
+
+/**
+ * Runs {@link migrate}, retrying while the database is still coming up. Callers get the last
+ * error if every attempt fails, so a genuinely broken migration still surfaces.
+ */
+export async function migrateWithRetry(
+  db: Db,
+  onRetry?: (attempt: number, delayMs: number, error: unknown) => void,
+  /** Tests only. */
+  deps: {
+    run?: (db: Db) => Promise<void>;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<void> {
+  const run = deps.run ?? migrate;
+  const sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await run(db);
+      return;
+    } catch (err) {
+      const delayMs = MIGRATE_RETRY_DELAYS_MS[attempt];
+      if (delayMs == null) {
+        throw err;
+      }
+      onRetry?.(attempt + 1, delayMs, err);
+      await sleep(delayMs);
+    }
+  }
+}
+
 export async function hasEntry(db: Db, botUsername: string, guid: string): Promise<boolean> {
   const rows = await db
     .select({ id: schema.feedEntries.id })

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,8 +21,9 @@ export async function migrate(db: Db): Promise<void> {
 const MIGRATE_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 15_000];
 
 /**
- * Runs {@link migrate}, retrying while the database is still coming up. Callers get the last
- * error if every attempt fails, so a genuinely broken migration still surfaces.
+ * Runs {@link migrate}, retrying on any failure -- the expected one being a database that is
+ * still coming up. Rethrows the last error once attempts are exhausted, so a genuinely broken
+ * migration surfaces after ~30s instead of retrying forever.
  */
 export async function migrateWithRetry(
   db: Db,


### PR DESCRIPTION
robot.villas 500'd on every route for ~10 minutes today, `/healthcheck` included.

rope rebooted at 20:24 while the hourly cron recreated the container, so `register()` ran about a minute before Postgres was back and `await migrate(db)` threw. Next re-runs the instrumentation hook per request, so every request re-threw the same `EHOSTUNREACH`. The process stayed up, so `restart: always` never fired and the poller never started. The DB was reachable again within a minute; the app never noticed. It took a manual `docker compose restart`.

`migrateWithRetry` retries over ~30s (1s/2s/4s/8s/15s), then `register()` exits 1. A blip is absorbed by the retries; anything longer — like today, where the DB was out for ~55s — is absorbed by Docker restarting the container. Either way the app converges instead of latching. The promise is pinned on `globalThis` so the retry window cannot put two migrations in flight.

Verified on the standalone output against an unreachable DB, per the boot-test recipe: one retry sequence, one FATAL, exit code 1 — with 25 concurrent requests in flight, which block until the process exits.

Unit tests cover the success, retry, and exhausted paths with injected `run`/`sleep`.