### PR TITLE
fix: move boot migration out of instrumentation.ts

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,3 @@
-const globalForBoot = globalThis as unknown as {
-  __robotVillasMigration?: Promise<void>;
-};
-
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") {
     return;
@@ -17,27 +13,8 @@ export async function register() {
   const { getLogger } = await import("@logtape/logtape");
   const logger = getLogger(["robot-villas", "server"]);
 
-  const { migrateWithRetry } = await import("@/lib/db");
-  try {
-    // Next re-runs register() per request until it succeeds. Pin the promise so the retry
-    // window can't put two migrations in flight at once.
-    globalForBoot.__robotVillasMigration ??= migrateWithRetry(db, (attempt, delayMs, error) => {
-      logger.warn("Migration attempt {attempt} failed, retrying in {delayMs}ms: {error}", {
-        attempt,
-        delayMs,
-        error,
-      });
-    });
-    await globalForBoot.__robotVillasMigration;
-  } catch (err) {
-    // Throwing would leave the process up and 500ing every request, so `restart: always`
-    // never fires. Exit and let Docker restart us.
-    logger.fatal("Database migrations failed, exiting so the container restarts: {error}", {
-      error: err,
-    });
-    process.exit(1);
-  }
-  logger.info("Database migrations complete");
+  const { migrateOrExit } = await import("@/lib/boot");
+  await migrateOrExit(db, logger);
 
   if (process.env.DISABLE_BACKGROUND === "true") {
     logger.info(

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -6,9 +6,8 @@ const globalForBoot = globalThis as unknown as {
 };
 
 /**
- * Migrates on startup, exiting the process if the database stays unreachable. Lives here
- * rather than in `instrumentation.ts` because that file is also compiled for the Edge
- * runtime, where `process.exit` is unsupported.
+ * Migrates on startup, exiting if it keeps failing. Not in `instrumentation.ts`: that file is
+ * also compiled for the Edge runtime, where `process.exit` is unsupported.
  */
 export async function migrateOrExit(db: Db, logger: Logger): Promise<void> {
   try {

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -1,0 +1,34 @@
+import type { Logger } from "@logtape/logtape";
+import { migrateWithRetry, type Db } from "./db";
+
+const globalForBoot = globalThis as unknown as {
+  __robotVillasMigration?: Promise<void>;
+};
+
+/**
+ * Migrates on startup, exiting the process if the database stays unreachable. Lives here
+ * rather than in `instrumentation.ts` because that file is also compiled for the Edge
+ * runtime, where `process.exit` is unsupported.
+ */
+export async function migrateOrExit(db: Db, logger: Logger): Promise<void> {
+  try {
+    // Next re-runs register() per request until it succeeds. Pin the promise so the retry
+    // window can't put two migrations in flight at once.
+    globalForBoot.__robotVillasMigration ??= migrateWithRetry(db, (attempt, delayMs, error) => {
+      logger.warn("Migration attempt {attempt} failed, retrying in {delayMs}ms: {error}", {
+        attempt,
+        delayMs,
+        error,
+      });
+    });
+    await globalForBoot.__robotVillasMigration;
+  } catch (err) {
+    // Throwing would leave the process up and 500ing every request, so `restart: always`
+    // never fires. Exit and let Docker restart us.
+    logger.fatal("Database migrations failed, exiting so the container restarts: {error}", {
+      error: err,
+    });
+    process.exit(1);
+  }
+  logger.info("Database migrations complete");
+}


### PR DESCRIPTION
Follow-up to #149 — this commit was on that branch, but the squash landed at `38c1924` and dropped it.

`instrumentation.ts` is compiled for the Edge runtime too, so `process.exit(1)` warns in the Turbopack build even though the `NEXT_RUNTIME !== "nodejs"` guard makes it unreachable. Moving `migrateOrExit` into `src/lib/boot.ts`, behind the same dynamic import the rest of the node-only setup uses, clears it: the edge chunk is now an empty `register()` and the build reports 0 warnings.

Nothing deploys to edge (empty middleware manifest, `node server.js` on the standalone output), so this is cosmetic. No behavior change.