### PR TITLE
fix: drop relay.intahnet.co.uk

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -1153,5 +1153,4 @@ follows:
 relays:
   - https://relay.toot.io/actor
   - https://relay.minecloud.ro/actor
-  - https://relay.intahnet.co.uk/actor
   - https://tags.pub/user/_____relay_____


### PR DESCRIPTION
## What

Every `Create` delivered to `https://relay.intahnet.co.uk/inbox` returns `400` with an empty body. Over the last 12h on mist:

| destination | errors/12h | status |
| --- | --- | --- |
| relay.intahnet.co.uk | 33,316 | 400, empty body |
| 8ball.space | 7,060 | 502 (follower instance down) |
| fediverse.tryptophonic.com | 1,188 | follower |
| everything else | <150 each | |

That is 66% of robot-villas' 50,688 errors, and the service wrote 1,975,055 log lines in 12h — the largest log producer on mist by an order of magnitude.

Cause is unknown. The relay actor still resolves (`GET /actor` → 200), `/status` shows the subscription `accepted` since Aug 17, and the other three relays never appear in the failure set. It may have dropped us server-side without a `Reject`.

## This PR is only half the fix

`getAcceptedRelays` (`src/lib/db.ts:621`) reads the DB, not config, so deleting the URL here does **not** stop delivery. Confirmed on rope:

```
url                                    | status   | has_inbox | count
https://relay.intahnet.co.uk/actor     | accepted | t         | 1
https://relay.minecloud.ro/actor       | accepted | t         | 1
https://relay.toot.io/actor            | accepted | t         | 1
https://tags.pub/user/_____relay_____  | accepted | t         | 1
```

`removeRelay` (`src/lib/db.ts:734`) exists but **has no callers**, and `subscribeToRelays` (`src/lib/federation.ts:959`) only prunes `pending`/`rejected` rows for non-designated bots via `pruneRedundantRelaySubscriptions`. So today there is no way to unsubscribe a relay short of editing the DB — a relay that goes bad is a permanent error source.

## Needs a decision from you

Two options, both yours to pick:

1. **Reconcile on startup** — have `subscribeToRelays` call `removeRelay` for accepted rows whose URL is no longer in `config.relays`. Makes this PR work as written, but means a config edit silently unsubscribes a relay. That is a behavior change to federation startup, so I did not write it.
2. **Leave config-driven removal out** and soft-delete the row directly:
   ```sql
   UPDATE relays SET deleted_at = now()
   WHERE url = 'https://relay.intahnet.co.uk/actor' AND deleted_at IS NULL;
   ```

Holding this as a draft until you decide which.