### PR TITLE
feat: unsubscribe from relays dropped out of feeds.yml

### DIFF
--- a/src/lib/__tests__/db.test.ts
+++ b/src/lib/__tests__/db.test.ts
@@ -25,6 +25,8 @@ import {
   upsertRelay,
   updateRelayStatus,
   getAllRelays,
+  getAcceptedRelays,
+  removeRelay,
   type Db,
 } from "../db";
 import * as schema from "../schema";
@@ -426,6 +428,29 @@ describeWithDb("database", () => {
 
       await seed();
       expect((await relayRow())!.statusChangedAt).toBeInstanceOf(Date);
+    });
+
+    it("removeRelay hides the row from getAllRelays and getAcceptedRelays", async () => {
+      // unsubscribeFromRemovedRelays is removeRelay's first caller, and
+      // delivery reads getAcceptedRelays -- so an accepted row has to stop
+      // being a delivery target, not just disappear from the listing.
+      await seed();
+      await updateRelayStatus(db, "https://robot.test/f/relay-1", "accepted");
+      expect((await getAcceptedRelays(db)).some((r) => r.url === URL)).toBe(true);
+
+      await removeRelay(db, "bot_a", URL);
+
+      expect(await relayRow()).toBeUndefined();
+      expect((await getAcceptedRelays(db)).some((r) => r.url === URL)).toBe(false);
+    });
+
+    it("removeRelay leaves other bots' rows for the same relay alone", async () => {
+      await seed();
+      await upsertRelay(db, "bot_b", URL, URL.replace("/actor", "/inbox"), URL, "https://robot.test/f/relay-2");
+
+      await removeRelay(db, "bot_a", URL);
+
+      expect((await getAllRelays(db, "bot_b")).some((r) => r.url === URL)).toBe(true);
     });
   });
 });

--- a/src/lib/__tests__/subscriptions.test.ts
+++ b/src/lib/__tests__/subscriptions.test.ts
@@ -8,6 +8,7 @@ import {
   RelayFollow,
   AS_PUBLIC,
   selectRemovedRelays,
+  normalizeIdUrl,
 } from "../subscriptions";
 
 const FOLLOW_ARGS = {
@@ -212,5 +213,19 @@ describe("selectRemovedRelays", () => {
       "https://relay.intahnet.co.uk/actor",
     ]);
     expect(removed).toEqual([]);
+  });
+});
+
+describe("normalizeIdUrl", () => {
+  it("treats the two trailing-slash forms as one url", () => {
+    // subscribeToRelays and unsubscribeFromRemovedRelays both key off this. If
+    // only one of them normalized, a slash-only feeds.yml edit would look like
+    // a removal to one and a brand new relay to the other -- and upsertRelay
+    // conflicts on (botUsername, url) exactly, so it would write a second row.
+    expect(normalizeIdUrl("https://relay.toot.io/actor/")).toBe(normalizeIdUrl("https://relay.toot.io/actor"));
+  });
+
+  it("leaves a url without a trailing slash alone", () => {
+    expect(normalizeIdUrl("https://relay.toot.io/actor")).toBe("https://relay.toot.io/actor");
   });
 });

--- a/src/lib/__tests__/subscriptions.test.ts
+++ b/src/lib/__tests__/subscriptions.test.ts
@@ -7,6 +7,7 @@ import {
   summarizeRelaySubscription,
   RelayFollow,
   AS_PUBLIC,
+  selectRemovedRelays,
 } from "../subscriptions";
 
 const FOLLOW_ARGS = {
@@ -180,5 +181,36 @@ describe("findLostAccepts", () => {
   it("skips rows with no resolved actor id", () => {
     const rows = [{ botUsername: "ghost", actorId: null }];
     expect(findLostAccepts(rows, new Set(["https://robot.villas/users/ghost"]))).toEqual([]);
+  });
+});
+
+describe("selectRemovedRelays", () => {
+  const rows = [
+    { url: "https://relay.toot.io/actor", botUsername: "nyt_homepage" },
+    { url: "https://relay.intahnet.co.uk/actor", botUsername: "nyt_homepage" },
+  ];
+
+  it("returns rows whose url is no longer configured", () => {
+    const removed = selectRemovedRelays(rows, ["https://relay.toot.io/actor"]);
+    expect(removed.map((r) => r.url)).toEqual(["https://relay.intahnet.co.uk/actor"]);
+  });
+
+  it("returns nothing when every row is still configured", () => {
+    expect(selectRemovedRelays(rows, rows.map((r) => r.url))).toEqual([]);
+  });
+
+  it("returns every row when the config lists no relays", () => {
+    // Emptying `relays:` has to unsubscribe, not no-op, or the last relay is
+    // unreachable through config.
+    expect(selectRemovedRelays(rows, [])).toHaveLength(2);
+  });
+
+  it("ignores a trailing slash difference", () => {
+    // Otherwise reformatting feeds.yml silently drops a relay we still want.
+    const removed = selectRemovedRelays(rows, [
+      "https://relay.toot.io/actor/",
+      "https://relay.intahnet.co.uk/actor",
+    ]);
+    expect(removed).toEqual([]);
   });
 });

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -37,7 +37,13 @@ import {
 } from "@fedify/vocab";
 import escapeHtml from "escape-html";
 import { getRelaySubscriptionBot, type BotConfig, type FeedsConfig } from "./config";
-import { findLostAccepts, isRelayTerminal, RelayFollow, selectRemovedRelays } from "./subscriptions";
+import {
+  findLostAccepts,
+  isRelayTerminal,
+  normalizeIdUrl,
+  RelayFollow,
+  selectRemovedRelays,
+} from "./subscriptions";
 import {
   addFollower,
   countEntries,
@@ -1042,8 +1048,14 @@ export async function subscribeToRelays(
 
   const allRelays = await getAllRelays(db);
 
-  const hasAcceptedForInstance = (url: string) =>
-    allRelays.some((r) => r.url === url && r.status === "accepted");
+  // Every URL comparison below normalizes trailing slashes, matching
+  // unsubscribeFromRemovedRelays. Strict equality here would read a slash-only
+  // feeds.yml edit as a brand new relay and, since upsertRelay conflicts on
+  // (botUsername, url) exactly, write a second row for a relay we already have.
+  const acceptedUrls = new Set(
+    allRelays.filter((r) => r.status === "accepted").map((r) => normalizeIdUrl(r.url)),
+  );
+  const hasAcceptedForInstance = (url: string) => acceptedUrls.has(normalizeIdUrl(url));
   // Terminal for the designated bot + URL. Rejects expire (see isRelayTerminal)
   // so a relay isn't frozen by a denial from a since-fixed format.
   const now = new Date();
@@ -1054,7 +1066,7 @@ export async function subscribeToRelays(
           r.botUsername === designated &&
           isRelayTerminal(r.status, r.statusChangedAt, now),
       )
-      .map((r) => r.url),
+      .map((r) => normalizeIdUrl(r.url)),
   );
 
   const signingIdentifier = botUsernames[0];
@@ -1087,7 +1099,7 @@ export async function subscribeToRelays(
       });
       continue;
     }
-    if (designatedTerminalUrls.has(relayUrl)) {
+    if (designatedTerminalUrls.has(normalizeIdUrl(relayUrl))) {
       logger.info("Designated bot {bot} has terminal state for relay {url}, skipping", {
         bot: designated,
         url: relayUrl,

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -37,7 +37,7 @@ import {
 } from "@fedify/vocab";
 import escapeHtml from "escape-html";
 import { getRelaySubscriptionBot, type BotConfig, type FeedsConfig } from "./config";
-import { findLostAccepts, isRelayTerminal, RelayFollow } from "./subscriptions";
+import { findLostAccepts, isRelayTerminal, RelayFollow, selectRemovedRelays } from "./subscriptions";
 import {
   addFollower,
   countEntries,
@@ -62,6 +62,7 @@ import {
   markFollowingAccepted,
   incrementLikeCount,
   pruneRedundantRelaySubscriptions,
+  removeRelay,
   removeAllEntries,
   removeAllFollowers,
   removeAllFollowing,
@@ -950,6 +951,64 @@ export async function repairFollowerInboxes(
 }
 
 /**
+ * Drops relay subscriptions whose URL has left feeds.yml, sending an
+ * `Undo(Follow)` first so the relay stops sending to us as well.
+ *
+ * Delivery targets come from `getAcceptedRelays`, which reads the DB, so
+ * without this a relay removed from config keeps receiving every `Create`
+ * forever — one that starts refusing them is a permanent error source with no
+ * way out short of editing the table by hand.
+ *
+ * The `Undo` is best effort: the row is soft-deleted either way, since a relay
+ * we cannot reach is exactly the case this usually cleans up after.
+ */
+export async function unsubscribeFromRemovedRelays(
+  ctx: Context<void>,
+  db: Db,
+  config: FeedsConfig,
+): Promise<void> {
+  const stale = selectRemovedRelays(await getAllRelays(db), config.relays ?? []);
+
+  for (const relay of stale) {
+    if (relay.status === "accepted" && relay.inboxUrl && relay.actorId && relay.followActivityId) {
+      try {
+        const actorUri = ctx.getActorUri(relay.botUsername);
+        await ctx.sendActivity(
+          { identifier: relay.botUsername },
+          { id: new URL(relay.actorId), inboxId: new URL(relay.inboxUrl), endpoints: null },
+          new Undo({
+            id: new URL(`${actorUri.href}#undo-relay-${relay.id}`),
+            actor: actorUri,
+            // RelayFollow, and the stored Follow id, so the activity we retract
+            // matches the one we sent byte for byte. See RelayFollow's docstring.
+            object: new RelayFollow({
+              id: new URL(relay.followActivityId),
+              actor: actorUri,
+              object: PUBLIC_COLLECTION,
+            }),
+          }),
+        );
+        logger.info("Sent Undo(Follow) to removed relay {url} from {bot}", {
+          url: relay.url,
+          bot: relay.botUsername,
+        });
+      } catch (error) {
+        logger.error("Failed to send Undo(Follow) to removed relay {url}: {error}", {
+          url: relay.url,
+          error,
+        });
+      }
+    }
+
+    await removeRelay(db, relay.botUsername, relay.url);
+    logger.info("Dropped relay {url} for {bot}: no longer in feeds.yml", {
+      url: relay.url,
+      bot: relay.botUsername,
+    });
+  }
+}
+
+/**
  * Subscribes to configured relays with a **single** bot (see
  * `relay_subscription_bot` in config, default: first bot). Many ActivityPub
  * relays treat one subscription per origin instance; sending a Follow from
@@ -961,6 +1020,8 @@ export async function subscribeToRelays(
   db: Db,
   config: FeedsConfig,
 ): Promise<void> {
+  await unsubscribeFromRemovedRelays(ctx, db, config);
+
   const relayUrls = config.relays ?? [];
   if (relayUrls.length === 0) {
     return;

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -86,8 +86,13 @@ export function summarizeRelaySubscription(
   return { status: "none", botUsername: null, statusChangedAt: null };
 }
 
-/** Instances vary on trailing slashes. */
-function normalizeActorId(id: string): string {
+/**
+ * Instances vary on trailing slashes, so every comparison between a URL we
+ * store and one we were handed goes through this. Relay bookkeeping keys on
+ * `(botUsername, url)` exactly, so treating the two forms as different URLs
+ * writes a second row for the same relay.
+ */
+export function normalizeIdUrl(id: string): string {
   return id.endsWith("/") ? id.slice(0, -1) : id;
 }
 
@@ -100,8 +105,8 @@ export function selectRemovedRelays<T extends { url: string }>(
   rows: ReadonlyArray<T>,
   configuredUrls: Iterable<string>,
 ): T[] {
-  const configured = new Set([...configuredUrls].map(normalizeActorId));
-  return rows.filter((row) => !configured.has(normalizeActorId(row.url)));
+  const configured = new Set([...configuredUrls].map(normalizeIdUrl));
+  return rows.filter((row) => !configured.has(normalizeIdUrl(row.url)));
 }
 
 /**
@@ -117,8 +122,8 @@ export function findLostAccepts(
   if (followerIds.size === 0) {
     return [];
   }
-  const normalized = new Set([...followerIds].map(normalizeActorId));
+  const normalized = new Set([...followerIds].map(normalizeIdUrl));
   return pending
-    .filter((row) => row.actorId !== null && normalized.has(normalizeActorId(row.actorId)))
+    .filter((row) => row.actorId !== null && normalized.has(normalizeIdUrl(row.actorId)))
     .map((row) => row.botUsername);
 }

--- a/src/lib/subscriptions.ts
+++ b/src/lib/subscriptions.ts
@@ -92,6 +92,19 @@ function normalizeActorId(id: string): string {
 }
 
 /**
+ * Relay rows whose URL is no longer in feeds.yml. Trailing slashes are
+ * normalized on both sides: a config edit that only adds or drops one must not
+ * read as a removal and unsubscribe a relay we still want.
+ */
+export function selectRemovedRelays<T extends { url: string }>(
+  rows: ReadonlyArray<T>,
+  configuredUrls: Iterable<string>,
+): T[] {
+  const configured = new Set([...configuredUrls].map(normalizeActorId));
+  return rows.filter((row) => !configured.has(normalizeActorId(row.url)));
+}
+
+/**
  * Pending follows the target already lists as followers — an Accept that was
  * delivered but never recorded. The target won't re-Accept a duplicate Follow,
  * so retrying can't clear these. Empty `followerIds` (hidden followers) yields


### PR DESCRIPTION
Follow-up to #151, which removed `relay.intahnet.co.uk` from `feeds.yml` but could not stop delivery on its own.

## The gap

Delivery targets come from `getAcceptedRelays` (`src/lib/db.ts:621`), which reads the DB. `removeRelay` (`src/lib/db.ts:734`) existed but had **no callers**, and `subscribeToRelays` only pruned `pending`/`rejected` rows for non-designated bots. So a relay dropped from config kept receiving every `Create` forever, and a relay that started refusing them — intahnet was 33,316 errors in 12h — could only be stopped by editing the table by hand.

## The change

`subscribeToRelays` now calls `unsubscribeFromRemovedRelays` first. For each relay row whose URL is no longer in `config.relays`:

1. Send `Undo(Follow)` to its inbox, reusing the stored `followActivityId` and `RelayFollow` so the retraction matches what we originally sent. Best effort — a relay we cannot reach is the usual reason we are here.
2. Soft-delete the row via `removeRelay`.

Two deliberate details:

- **Trailing slashes are normalized** on both sides of the comparison, reusing the same helper `findLostAccepts` uses. Reformatting `feeds.yml` must not silently unsubscribe a relay.
- **Emptying `relays:` does unsubscribe.** The reconcile runs before the `relayUrls.length === 0` early return, otherwise the last relay would be unreachable through config.

This is the behavior change you picked over the manual `UPDATE`: a config edit is now what unsubscribes a relay.

## Tests

- `selectRemovedRelays` unit tests in `subscriptions.test.ts` — removal, no-op, empty config, trailing-slash equivalence.
- Two `removeRelay` DB tests in `db.test.ts`: an accepted row stops being returned by `getAcceptedRelays` (not just `getAllRelays`), and another bot's row for the same relay survives. These are the first coverage `removeRelay` has had; they run in CI against the `postgres:16` service and skip locally without `DATABASE_URL`, so **I have not executed them myself** — worth watching the CI run.

Local: `tsc --noEmit` clean, eslint clean, 172 passed / 30 skipped.

## After merge

`relay.intahnet.co.uk` is already out of `feeds.yml` on main, so the first boot with this deployed sends the `Undo` and drops the row. Expect robot-villas' error volume to fall by roughly two thirds and its log volume by most of 1.85M lines/12h.