### PR TITLE
feat: block federating with instances that always refuse us

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -1155,9 +1155,9 @@ follows:
 # subdomains. Each of these refuses us permanently, and without this list every
 # post retries against them until the queue gives up.
 blocked_instances:
-  - horche.demkontinuum.de  # Friendica, 403 "Bots are not allowed" -- policy, not an outage
-  - fediverse.tryptophonic.com  # 401 on every delivery
-  - 8ball.space  # 502 then 405; instance has been broken for days
+  - horche.demkontinuum.de # Friendica, 403 "Bots are not allowed" -- policy, not an outage
+  - fediverse.tryptophonic.com # 401 on every delivery
+  - 8ball.space # 502 then 405; instance has been broken for days
 relays:
   - https://relay.toot.io/actor
   - https://relay.minecloud.ro/actor

--- a/feeds.yml
+++ b/feeds.yml
@@ -1150,6 +1150,14 @@ relay_subscription_bot: nyt_homepage
 follows:
   - '@icco@merveilles.town'
   - '@_followback@tags.pub'
+# Instances we will not federate with: their Follows are Rejected and they are
+# dropped from every delivery. Hostnames, not URLs; a domain also blocks its
+# subdomains. Each of these refuses us permanently, and without this list every
+# post retries against them until the queue gives up.
+blocked_instances:
+  - horche.demkontinuum.de  # Friendica, 403 "Bots are not allowed" -- policy, not an outage
+  - fediverse.tryptophonic.com  # 401 on every delivery
+  - 8ball.space  # 502 then 405; instance has been broken for days
 relays:
   - https://relay.toot.io/actor
   - https://relay.minecloud.ro/actor

--- a/src/lib/__tests__/blocklist.test.ts
+++ b/src/lib/__tests__/blocklist.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildBlocklist,
+  isBlockedHost,
+  normalizeHost,
+  partitionBlockedRecipients,
+} from "../blocklist";
+
+describe("normalizeHost", () => {
+  it("lowercases", () => {
+    expect(normalizeHost("Example.COM")).toBe("example.com");
+  });
+
+  it("accepts a pasted url instead of a bare host", () => {
+    // blocked_instances is hand-edited; pasting the inbox URL is the obvious slip.
+    expect(normalizeHost("https://example.com/inbox")).toBe("example.com");
+    expect(normalizeHost("example.com/inbox")).toBe("example.com");
+  });
+
+  it("strips the DNS root dot", () => {
+    expect(normalizeHost("example.com.")).toBe("example.com");
+  });
+
+  it("returns empty for blank input", () => {
+    expect(normalizeHost("   ")).toBe("");
+  });
+});
+
+describe("isBlockedHost", () => {
+  const blocked = buildBlocklist(["evil.com", "8ball.space"]);
+
+  it("matches the exact host", () => {
+    expect(isBlockedHost("evil.com", blocked)).toBe(true);
+  });
+
+  it("matches subdomains of a blocked domain", () => {
+    // Otherwise a blocked instance walks straight back in as a subdomain.
+    expect(isBlockedHost("mastodon.evil.com", blocked)).toBe(true);
+  });
+
+  it("does not match a host that merely ends with the same letters", () => {
+    expect(isBlockedHost("notevil.com", blocked)).toBe(false);
+  });
+
+  it("does not match a parent of a blocked host", () => {
+    expect(isBlockedHost("space", blocked)).toBe(false);
+  });
+
+  it("is case and trailing-dot insensitive", () => {
+    expect(isBlockedHost("EVIL.com.", blocked)).toBe(true);
+  });
+
+  it("returns false for an empty blocklist", () => {
+    expect(isBlockedHost("evil.com", new Set())).toBe(false);
+  });
+});
+
+describe("buildBlocklist", () => {
+  it("drops blanks and normalizes entries", () => {
+    const set = buildBlocklist([" Evil.COM ", "", "   ", "https://8ball.space/inbox"]);
+    expect([...set].sort()).toEqual(["8ball.space", "evil.com"]);
+  });
+});
+
+describe("partitionBlockedRecipients", () => {
+  const rec = (host: string) => ({ inboxId: new URL(`https://${host}/inbox`) });
+
+  it("splits recipients by blocked host", () => {
+    const blocked = buildBlocklist(["evil.com"]);
+    const { allowed, blockedHosts } = partitionBlockedRecipients(
+      [rec("good.example"), rec("evil.com"), rec("shard.evil.com")],
+      blocked,
+    );
+    expect(allowed.map((r) => r.inboxId.hostname)).toEqual(["good.example"]);
+    expect(blockedHosts).toEqual(["evil.com", "shard.evil.com"]);
+  });
+
+  it("passes everything through when nothing is blocked", () => {
+    const recipients = [rec("a.example"), rec("b.example")];
+    const { allowed, blockedHosts } = partitionBlockedRecipients(recipients, new Set());
+    expect(allowed).toHaveLength(2);
+    expect(blockedHosts).toEqual([]);
+  });
+
+  it("treats a recipient with no inbox as not blocked", () => {
+    // Malformed rows are somebody else's problem; swallowing them here would
+    // hide them from whatever should be reporting them.
+    const { allowed, blockedHosts } = partitionBlockedRecipients(
+      [{ inboxId: null }],
+      buildBlocklist(["evil.com"]),
+    );
+    expect(allowed).toHaveLength(1);
+    expect(blockedHosts).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { getBlockedInstances, getRelaySubscriptionBot, parseConfig, loadConfig } from "../config";
+import { getBlockedInstances, getRelaySubscriptionBot, parseConfig, loadConfig, resolveBlockedInstances } from "../config";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { load as parseYaml } from "js-yaml";
@@ -289,5 +289,35 @@ describe("getBlockedInstances", () => {
     expect(blocked.size).toBe(2);
     expect(blocked.has("spam.example.com")).toBe(true);
     expect(blocked.has("bad.instance")).toBe(true);
+  });
+});
+
+describe("resolveBlockedInstances", () => {
+  const yaml = (blocked?: string) => `
+bots:
+  a:
+    feed_url: "https://e.test/f.xml"
+    display_name: "A"
+    summary: "s"
+${blocked ?? ""}`;
+
+  afterEach(() => {
+    delete process.env.BLOCKED_INSTANCES;
+  });
+
+  it("unions feeds.yml with the env override", () => {
+    process.env.BLOCKED_INSTANCES = "fromenv.test";
+    const cfg = parseConfig(yaml('blocked_instances:\n  - "fromyaml.test"'));
+    expect([...resolveBlockedInstances(cfg)].sort()).toEqual(["fromenv.test", "fromyaml.test"]);
+  });
+
+  it("defaults to empty when neither is set", () => {
+    expect(resolveBlockedInstances(parseConfig(yaml())).size).toBe(0);
+  });
+
+  it("normalizes what it reads from yaml", () => {
+    // A pasted inbox URL and stray case must not create an entry that never matches.
+    const cfg = parseConfig(yaml('blocked_instances:\n  - " Evil.COM "\n  - "https://x.test/inbox"'));
+    expect([...resolveBlockedInstances(cfg)].sort()).toEqual(["evil.com", "x.test"]);
   });
 });

--- a/src/lib/__tests__/poller.test.ts
+++ b/src/lib/__tests__/poller.test.ts
@@ -60,7 +60,7 @@ function makeConfig(botCount: number): FeedsConfig {
       summary: "A test bot",
     };
   }
-  return { bots, follows: [], relays: [] };
+  return { bots, follows: [], relays: [], blocked_instances: [] };
 }
 
 describe("startPoller concurrency", () => {

--- a/src/lib/blocklist.ts
+++ b/src/lib/blocklist.ts
@@ -1,0 +1,91 @@
+/** Instance blocklist: what we refuse to federate with, in both directions. */
+
+/**
+ * Lowercased hostname for comparison. Accepts a bare host or a full URL, since
+ * `blocked_instances` is hand-edited and pasting `https://example.com/inbox`
+ * is the obvious mistake. A trailing dot (the DNS root) is stripped so
+ * `example.com.` and `example.com` are one host.
+ */
+export function normalizeHost(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed === "") {
+    return "";
+  }
+  let host = trimmed;
+  if (host.includes("/") || host.includes(":")) {
+    try {
+      host = new URL(host.includes("//") ? host : `https://${host}`).hostname;
+    } catch {
+      // Not a URL after all; fall through and treat it as a bare host.
+      host = trimmed;
+    }
+  }
+  return host.toLowerCase().replace(/\.$/, "");
+}
+
+/** Builds the comparison set. Empty and unparseable entries drop out. */
+export function buildBlocklist(hosts: Iterable<string>): ReadonlySet<string> {
+  const set = new Set<string>();
+  for (const raw of hosts) {
+    const host = normalizeHost(raw);
+    if (host !== "") {
+      set.add(host);
+    }
+  }
+  return set;
+}
+
+/**
+ * Whether `host` is blocked. Blocking a domain blocks its subdomains too —
+ * that is what every other fediverse server means by a domain block, and
+ * without it a blocked instance walks back in as `mastodon.example.com`.
+ * Matching is suffix-on-a-label-boundary, so `notevil.com` is not caught by
+ * a block on `evil.com`.
+ */
+export function isBlockedHost(host: string, blocked: ReadonlySet<string>): boolean {
+  if (blocked.size === 0) {
+    return false;
+  }
+  const needle = normalizeHost(host);
+  if (needle === "") {
+    return false;
+  }
+  if (blocked.has(needle)) {
+    return true;
+  }
+  for (const domain of blocked) {
+    if (needle.endsWith(`.${domain}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Splits delivery recipients into those we will send to and those we will not.
+ * Callers log the blocked count rather than dropping it silently — a blocklist
+ * that quietly eats deliveries is indistinguishable from a delivery bug.
+ *
+ * An `inboxId` we cannot parse is treated as not blocked: the blocklist is not
+ * the right place to reject malformed rows, and swallowing them here would
+ * hide them from whatever does.
+ */
+export function partitionBlockedRecipients<T extends { inboxId?: URL | null }>(
+  recipients: ReadonlyArray<T>,
+  blocked: ReadonlySet<string>,
+): { allowed: T[]; blockedHosts: string[] } {
+  if (blocked.size === 0) {
+    return { allowed: [...recipients], blockedHosts: [] };
+  }
+  const allowed: T[] = [];
+  const blockedHosts: string[] = [];
+  for (const r of recipients) {
+    const host = r.inboxId ? normalizeHost(r.inboxId.hostname) : "";
+    if (host !== "" && isBlockedHost(host, blocked)) {
+      blockedHosts.push(host);
+    } else {
+      allowed.push(r);
+    }
+  }
+  return { allowed, blockedHosts };
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { load as parseYaml } from "js-yaml";
 import { z } from "zod";
+import { buildBlocklist } from "./blocklist";
 
 const MAX_DISPLAY_NAME_LENGTH = 100;
 const MAX_SUMMARY_LENGTH = 500;
@@ -27,6 +28,13 @@ export const FeedsConfigSchema = z
       .refine((bots) => Object.keys(bots).length > 0, "At least one bot must be defined"),
     follows: z.array(z.string().min(3)).optional().default([]),
     relays: z.array(z.string().url()).optional().default([]),
+    /**
+     * Instances we refuse to federate with, in both directions: their Follows
+     * are Rejected and they are dropped from every delivery. Hostnames, not
+     * URLs; blocking a domain blocks its subdomains. Unioned with the
+     * BLOCKED_INSTANCES env var.
+     */
+    blocked_instances: z.array(z.string().min(1)).optional().default([]),
     /**
      * Single bot that sends `Follow` to each relay. Relays expect one subscription per
      * instance; all bots still publish `Create` to a relay if any subscription is accepted.
@@ -72,18 +80,24 @@ export function parseConfig(yaml: string): FeedsConfig {
 }
 
 /**
- * Returns the set of blocked instance hostnames (lowercase) from env
- * BLOCKED_INSTANCES (comma-separated). Used to Reject Follow from those instances.
+ * Blocked instance hostnames from env BLOCKED_INSTANCES (comma-separated).
+ * Kept as a break-glass override so a host can be blocked without a deploy;
+ * the durable list lives in `blocked_instances` in feeds.yml. Prefer
+ * `resolveBlockedInstances`, which unions the two.
  */
 export function getBlockedInstances(): Set<string> {
   const raw = process.env.BLOCKED_INSTANCES;
   if (!raw || typeof raw !== "string") {
     return new Set();
   }
-  return new Set(
-    raw
-      .split(",")
-      .map((h) => h.trim().toLowerCase())
-      .filter(Boolean),
-  );
+  return new Set(buildBlocklist(raw.split(",")));
+}
+
+/**
+ * The effective blocklist: `blocked_instances` from feeds.yml plus anything in
+ * BLOCKED_INSTANCES. One set governs both inbound Follows and outbound
+ * delivery, so the two directions cannot drift apart.
+ */
+export function resolveBlockedInstances(config: FeedsConfig): ReadonlySet<string> {
+  return buildBlocklist([...(config.blocked_instances ?? []), ...getBlockedInstances()]);
 }

--- a/src/lib/federation.ts
+++ b/src/lib/federation.ts
@@ -36,6 +36,7 @@ import {
   Update,
 } from "@fedify/vocab";
 import escapeHtml from "escape-html";
+import { isBlockedHost, normalizeHost } from "./blocklist";
 import { getRelaySubscriptionBot, type BotConfig, type FeedsConfig } from "./config";
 import {
   findLostAccepts,
@@ -93,7 +94,7 @@ export interface FederationDeps {
   kvStore: KvStore;
   messageQueue: MessageQueue;
   origin: string;
-  blockedInstances?: Set<string>;
+  blockedInstances?: ReadonlySet<string>;
 }
 
 const logger = getLogger(["robot-villas", "federation"]);
@@ -217,7 +218,7 @@ async function handleFollow(
   follow: Follow,
   db: Db,
   botUsernames: string[],
-  blockedInstances: Set<string>,
+  blockedInstances: ReadonlySet<string>,
 ): Promise<void> {
   if (!follow.id || !follow.actorId || !follow.objectId) {
     logger.warn("Follow ignored: missing id, actorId, or objectId");
@@ -237,8 +238,10 @@ async function handleFollow(
     });
     return;
   }
-  const followerHost = follower.id.hostname.toLowerCase();
-  if (blockedInstances.has(followerHost)) {
+  // Same predicate as outbound delivery, so a domain block covers subdomains
+  // here too and the two directions cannot disagree about what is blocked.
+  const followerHost = normalizeHost(follower.id.hostname);
+  if (isBlockedHost(followerHost, blockedInstances)) {
     logger.info("Rejected follow from blocked instance {host}", {
       host: followerHost,
     });

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -1,6 +1,6 @@
 import { PostgresKvStore, PostgresMessageQueue } from "@fedify/postgres";
 import postgres from "postgres";
-import { getBlockedInstances, loadConfig } from "./config";
+import { loadConfig, resolveBlockedInstances } from "./config";
 import { createDb } from "./db";
 import { setupFederation } from "./federation";
 
@@ -27,7 +27,7 @@ function initGlobals() {
   const config = loadConfig("feeds.yml");
   const kvStore = new PostgresKvStore(sql);
   const messageQueue = new PostgresMessageQueue(sql);
-  const blockedInstances = getBlockedInstances();
+  const blockedInstances = resolveBlockedInstances(config);
   const federation = setupFederation({
     config,
     db,

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -1,6 +1,6 @@
 import type { Context } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
-import type { BotConfig, FeedsConfig } from "./config";
+import { resolveBlockedInstances, type BotConfig, type FeedsConfig } from "./config";
 import { mapWithConcurrency } from "./concurrency";
 import { getFeedPollStatusMap, upsertFeedPollStatus, type Db, type FeedPollStatusRow } from "./db";
 import { parsePositiveInt } from "./env";
@@ -29,6 +29,8 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
   const intervalMs = parsePositiveInt(opts.intervalMs, DEFAULT_INTERVAL_MS);
   const concurrency = parsePositiveInt(opts.concurrency, DEFAULT_CONCURRENCY);
   const botNames = Object.keys(config.bots);
+  // Resolved once per poller, not per entry: the list only changes on redeploy.
+  const blockedInstances = resolveBlockedInstances(config);
 
   let stopped = false;
 
@@ -91,7 +93,7 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
         logger.info("Feed unchanged for {username} (HTTP 304)", { username });
         return;
       }
-      const result = await publishNewEntries(ctx, db, username, domain, fetchResult.entries, bot);
+      const result = await publishNewEntries(ctx, db, username, domain, fetchResult.entries, bot, blockedInstances);
       logger.info(
         "Fetched {entryCount} entries for {username}, published {published}, skipped {skipped}",
         {

--- a/src/lib/publisher.ts
+++ b/src/lib/publisher.ts
@@ -3,6 +3,7 @@ import type { Context } from "@fedify/fedify";
 import { Create, Hashtag, Note, PUBLIC_COLLECTION, type Recipient } from "@fedify/vocab";
 import escapeHtml from "escape-html";
 import { getLogger } from "@logtape/logtape";
+import { partitionBlockedRecipients } from "./blocklist";
 import type { BotConfig } from "./config";
 import { getAcceptedRelays, getExistingGuids, getFollowerRecipients, insertEntry, type Db } from "./db";
 import { resolveHashtags } from "./hashtags";
@@ -90,12 +91,13 @@ export async function publishNewEntries(
   domain: string,
   entries: FeedEntry[],
   bot: BotConfig,
+  blockedInstances: ReadonlySet<string> = new Set(),
 ): Promise<PublishResult> {
   let published = 0;
   let skipped = 0;
 
   const followerRows = await getFollowerRecipients(db, botUsername);
-  const followerRecipients: Recipient[] = followerRows
+  const allFollowerRecipients: Recipient[] = followerRows
     .filter((f) => f.sharedInboxUrl)
     .map((f) => ({
       id: new URL(f.followerId),
@@ -103,13 +105,30 @@ export async function publishNewEntries(
       endpoints: null,
     }));
   const relays = await getAcceptedRelays(db);
-  const relayRecipients: Recipient[] = relays
+  const allRelayRecipients: Recipient[] = relays
     .filter((r) => r.inboxUrl && r.actorId)
     .map((r) => ({
       id: new URL(r.actorId!),
       inboxId: new URL(r.inboxUrl!),
       endpoints: null,
     }));
+
+  // Blocked hosts are dropped here rather than at follow time: a host can be
+  // blocked long after it followed, and rows for it stay in the DB.
+  const followers = partitionBlockedRecipients(allFollowerRecipients, blockedInstances);
+  const relayed = partitionBlockedRecipients(allRelayRecipients, blockedInstances);
+  const followerRecipients = followers.allowed;
+  const relayRecipients = relayed.allowed;
+  const blockedHosts = [...new Set([...followers.blockedHosts, ...relayed.blockedHosts])];
+  if (blockedHosts.length > 0) {
+    // Counted, not silent: a blocklist that quietly eats deliveries looks
+    // exactly like a delivery bug.
+    logger.info("Skipping {count} blocked recipient(s) for {identifier}: {hosts}", {
+      identifier: botUsername,
+      count: followers.blockedHosts.length + relayed.blockedHosts.length,
+      hosts: blockedHosts.join(", "),
+    });
+  }
 
   const hasRecipients = followerRecipients.length > 0 || relayRecipients.length > 0;
 


### PR DESCRIPTION
## Why

`BLOCKED_INSTANCES` already existed, but it only gated inbound `Follow` in `handleFollow` — and it is **not set on robot-villas in production**, so `getBlockedInstances()` has always returned an empty set. It was dead code, and nothing at all stopped us delivering to hosts that reject every activity we send.

After #152 removed the dead relay, the residual error volume is entirely three such hosts:

| host | status | why it will not improve |
| --- | --- | --- |
| horche.demkontinuum.de | 403 | Friendica: "Bots are not allowed" — an instance policy |
| fediverse.tryptophonic.com | 401 | rejects our signature on every delivery |
| 8ball.space | 502, now 405 | broken for days |

~10k errors / 12h between them, retried forever.

## What

- **`blocked_instances` in `feeds.yml`** is the durable list, alongside `relays` and `follows`. `BLOCKED_INSTANCES` stays as a break-glass override so a host can be blocked without a deploy; `resolveBlockedInstances(config)` unions the two.
- **One set governs both directions.** `globals.ts` now resolves it and hands the same set to inbound Follow handling and to delivery, so the two cannot drift. That drift is exactly the class of bug Copilot caught in #152.
- **Outbound filtering in `publisher.ts`** partitions both follower and relay recipients before send.
- **Domain blocks cover subdomains**, matching every other fediverse server — otherwise a blocked instance walks back in as `mastodon.example.com`. Matching is suffix-on-a-label-boundary, so `notevil.com` is not caught by a block on `evil.com`.
- **Blocked deliveries are logged with a count**, not dropped silently. A blocklist that quietly eats deliveries is indistinguishable from a delivery bug.
- `normalizeHost` accepts a pasted URL and strips case and the DNS root dot, because `blocked_instances` is hand-edited and `https://example.com/inbox` is the obvious slip.

## Tests

14 new blocklist tests plus 3 for the config resolver, covering subdomain matching, the `notevil.com` near-miss, pasted URLs, the env/yaml union, and a null inbox passing through untouched. Local: 191 passed / 30 skipped, `tsc --noEmit` and eslint clean.

## Deliberately not included

**Automatic blocking on repeated permanent rejections.** A 403/401/405 counter that trips a threshold is a different feature: it would sever real followers on a transient misconfiguration, and it needs a decay and an unblock path to be safe. Worth doing, but as its own change with its own thinking — say the word and I will spec it.